### PR TITLE
Create compound forms structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vector-im/compound-design-tokens",
+  "name": "@vector-im/compound-web",
   "version": "0.0.1",
   "description": "Compound components for the Web",
   "type": "module",
@@ -83,7 +83,8 @@
     "vite-plugin-svgr": "^2.4.0"
   },
   "dependencies": {
-    "@vector-im/compound-design-tokens": "https://github.com/vector-im/compound-design-tokens#develop",
+    "@radix-ui/react-form": "^0.0.2",
+    "@vector-im/compound-design-tokens": "https://github.com/vector-im/compound-design-tokens#main",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/src/components/Form/Control.tsx
+++ b/src/components/Form/Control.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Control as RadixControl } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+
+type ControlProps = {
+  className?: string;
+} & React.ComponentProps<typeof RadixControl>;
+
+/**
+ * Thin wrapper around Radix UI Control component
+ * https://www.radix-ui.com/docs/primitives/components/form#control
+ */
+export function Control({
+  children,
+  ...props
+}: PropsWithChildren<ControlProps>): JSX.Element {
+  const classes = classNames(styles.control, props.className);
+  return (
+    <RadixControl {...props} className={classes}>
+      {children}
+    </RadixControl>
+  );
+}

--- a/src/components/Form/Field.tsx
+++ b/src/components/Form/Field.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Field as RadixField } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+
+type FieldProps = {
+  className?: string;
+} & React.ComponentProps<typeof RadixField>;
+
+/**
+ * Thin wrapper around Radix UI Field component
+ * https://www.radix-ui.com/docs/primitives/components/form#field
+ */
+export function Field({
+  children,
+  ...props
+}: PropsWithChildren<FieldProps>): JSX.Element {
+  const classes = classNames(styles.field, props.className);
+  return (
+    <RadixField {...props} className={classes}>
+      {children}
+    </RadixField>
+  );
+}

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+
+import * as Form from "./index";
+
+export default {
+  title: "Form",
+  component: Form.Root,
+} as Meta<typeof Form.Root>;
+
+const Template: StoryFn<typeof Form.Root> = () => (
+  <Form.Root>
+    <Form.Field name="mxid">
+      <Form.Label>Username</Form.Label>
+      <Form.Control disabled value="Hello world!" />
+    </Form.Field>
+
+    <Form.Submit>Submit</Form.Submit>
+  </Form.Root>
+);
+
+export const Root = Template.bind({});
+Root.args = {};

--- a/src/components/Form/Label.tsx
+++ b/src/components/Form/Label.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Label as RadixLabel } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+
+type LabelProps = {
+  className?: string;
+} & React.ComponentProps<typeof RadixLabel>;
+
+/**
+ * Thin wrapper around Radix UI Label component
+ * https://www.radix-ui.com/docs/primitives/components/form#label
+ */
+export function Label({
+  children,
+  ...props
+}: PropsWithChildren<LabelProps>): JSX.Element {
+  const classes = classNames(styles.label, props.className);
+  return (
+    <RadixLabel {...props} className={classes}>
+      {children}
+    </RadixLabel>
+  );
+}

--- a/src/components/Form/Message.tsx
+++ b/src/components/Form/Message.tsx
@@ -1,0 +1,43 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Message as RadixMessage } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+
+type MessageProps = {
+  className?: string;
+} & React.ComponentProps<typeof RadixMessage>;
+
+/**
+ * Thin wrapper around Radix UI Message component
+ * https://www.radix-ui.com/docs/primitives/components/form#message
+ */
+export function Message({
+  children,
+  ...props
+}: PropsWithChildren<MessageProps>): JSX.Element {
+  const classes = classNames(styles.message, props.className);
+  return (
+    <RadixMessage {...props} className={classes}>
+      {/* Pending to be replaced by the alert component, see 
+          https://github.com/vector-im/compound-web/pull/6 */}
+      {children}
+    </RadixMessage>
+  );
+}

--- a/src/components/Form/Root.tsx
+++ b/src/components/Form/Root.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Root as RadixRoot } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+
+type RootProps = {
+  className?: string;
+} & React.ComponentProps<typeof RadixRoot>;
+
+/**
+ * Thin wrapper around Radix UI Root component
+ * https://www.radix-ui.com/docs/primitives/components/form#root
+ */
+export function Root({
+  children,
+  ...props
+}: PropsWithChildren<RootProps>): JSX.Element {
+  const classes = classNames(styles.root, props.className);
+  return (
+    <RadixRoot {...props} className={classes}>
+      {children}
+    </RadixRoot>
+  );
+}

--- a/src/components/Form/Submit.tsx
+++ b/src/components/Form/Submit.tsx
@@ -1,0 +1,46 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { PropsWithChildren } from "react";
+import { Submit as RadixSubmit } from "@radix-ui/react-form";
+
+import styles from "./form.module.css";
+import classNames from "classnames";
+import { Button } from "../Button/Button";
+
+type SubmitProps = {
+  className?: string;
+  size?: React.ComponentProps<typeof Button>["size"];
+} & React.ComponentProps<typeof RadixSubmit>;
+
+/**
+ * Thin wrapper around Radix UI Submit component
+ * https://www.radix-ui.com/docs/primitives/components/form#submit
+ */
+export function Submit({
+  children,
+  size,
+  ...props
+}: PropsWithChildren<SubmitProps>): JSX.Element {
+  const classes = classNames(styles.submit, props.className);
+  return (
+    <RadixSubmit {...props} asChild>
+      <Button type="submit" size={size} className={classes}>
+        {children}
+      </Button>
+    </RadixSubmit>
+  );
+}

--- a/src/components/Form/ValidityState.tsx
+++ b/src/components/Form/ValidityState.tsx
@@ -1,0 +1,29 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+import { ValidityState as RadixValidityState } from "@radix-ui/react-form";
+
+/**
+ * Thin wrapper around Radix UI ValidityState component
+ * https://www.radix-ui.com/docs/primitives/components/form#validitystate
+ */
+export function ValidityState({
+  children,
+  ...props
+}: React.ComponentProps<typeof RadixValidityState>): JSX.Element {
+  return <RadixValidityState {...props}>{children}</RadixValidityState>;
+}

--- a/src/components/Form/form.module.css
+++ b/src/components/Form/form.module.css
@@ -1,0 +1,93 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Styling the Radix UI Form component */
+
+/**
+ * ROOT: Form Element
+ */
+
+.root {
+  font: var(--cpd-font-body-md-regular);
+  letter-spacing: var(--cpd-font-letter-spacing-body-md);
+}
+
+/**
+ * FIELD: Wrapper around label, control and message
+ */
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+/**
+ * LABEL
+ */
+
+.label {
+  font-weight: var(--cpd-font-weight-medium);
+}
+
+.label[for] {
+  cursor: pointer;
+}
+
+.label[data-invalid] {
+  color: var(--cpd-color-text-action-critical);
+}
+
+/* Currently working everywhere but on Firefox (only behind a labs flag)
+ https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility */
+.label:has(~ .control[disabled]) {
+  color: var(--cpd-color-text-disabled);
+  cursor: not-allowed;
+}
+
+/**
+ * CONTROL
+ */
+
+.control {
+  --cpd-form-border-color: var(--cpd-color-gray-600);
+  --cpd-form-bg: var(--cpd-color-bg-canvas);
+
+  border: 1px solid var(--cpd-form-border-color);
+  background: var(--cpd-form-bg);
+  border-radius: 8px;
+  padding: var(--cpd-space-3x) var(--cpd-space-4x);
+}
+
+.control:hover {
+  --cpd-form-border-color: var(--cpd-color-gray-1100);
+}
+
+.control:focus {
+  outline: 3px solid var(--cpd-color-blue-900);
+  border-color: transparent;
+}
+
+.control[data-invalid] {
+  --cpd-form-border-color: var(--cpd-color-text-action-critical);
+}
+
+.control[disabled] {
+  --cpd-form-bg: var(--cpd-color-gray-200);
+  --cpd-form-border-color: var(--cpd-color-gray-500);
+
+  color: var(--cpd-color-text-disabled);
+  cursor: not-allowed;
+}

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2023  New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Extends Radix UI forms
+ * https://www.radix-ui.com/docs/primitives/components/form
+ */
+
+export { Root } from "./Root";
+export { Field } from "./Field";
+export { Label } from "./Label";
+export { Control } from "./Control";
+export { Message } from "./Message";
+export { ValidityState } from "./ValidityState";
+export { Submit } from "./Submit";

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
+import React, { PropsWithChildren } from "react";
 
 type TypographyProps<C extends React.ElementType> = {
   as?: C;
-  children: React.ReactNode;
   type?: "body" | "heading";
   weight?: "regular" | "semibold" | "medium" | "bold";
   size?: "xs" | "sm" | "md" | "lg";
@@ -31,7 +30,7 @@ export const Typography = <C extends React.ElementType = "p">({
   weight = "regular",
   size = "md",
   ...restProps
-}: TypographyProps<C>) => {
+}: PropsWithChildren<TypographyProps<C>>) => {
   const Component = as || "p";
 
   return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,7 +57,7 @@ limitations under the License.
       url("/fonts/Inter/Inter-Bold.woff") format("woff");
 }
 
-html, body {
+html, body, input {
   font: var(--cpd-font-body-md-regular);
   color: var(--cpd-color-text-primary);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,7 +1021,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -1705,6 +1705,79 @@
     "@percy/cli-command" "^1.10.4"
     cross-spawn "^7.0.3"
     qs "^6.11.0"
+
+"@radix-ui/primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
+  integrity sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
+  integrity sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
+  integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-form@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-form/-/react-form-0.0.2.tgz#1ac64048c6297e77f37c222269b444f803ee4ac0"
+  integrity sha512-+WQU4Gs4MqjYsHwh5d19Ka4CMcWeXd7WPuWYCYGtNbDRMHFG2TtgM9PlEK4Yrk7wG1f5/da6Bgtteky2ggDXUg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-label" "2.0.1"
+    "@radix-ui/react-primitive" "1.0.2"
+
+"@radix-ui/react-id@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.0.tgz#8d43224910741870a45a8c9d092f25887bb6d11e"
+  integrity sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-label@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.0.1.tgz#c05c41cb20f7877d6e9c3eac731b11584c95b2fa"
+  integrity sha512-qcfbS3B8hTYmEO44RNcXB6pegkxRsJIbdxTMu0PEX0Luv5O2DvTIwwVYxQfUwLpM88EL84QRPLOLgwUSApMsLQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.2"
+
+"@radix-ui/react-primitive@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz#54e22f49ca59ba88d8143090276d50b93f8a7053"
+  integrity sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-slot@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.1.tgz#e7868c669c974d649070e9ecbec0b367ee0b4d81"
+  integrity sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-use-layout-effect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
+  integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@rollup/pluginutils@^4.2.0":
   version "4.2.1"
@@ -3059,9 +3132,9 @@
     "@typescript-eslint/types" "5.54.1"
     eslint-visitor-keys "^3.3.0"
 
-"@vector-im/compound-design-tokens@https://github.com/vector-im/compound-design-tokens#develop":
+"@vector-im/compound-design-tokens@https://github.com/vector-im/compound-design-tokens#main":
   version "0.0.2"
-  resolved "https://github.com/vector-im/compound-design-tokens#23d6005a7e865ea1eb2fdbde0b209a8f7ee75b76"
+  resolved "https://github.com/vector-im/compound-design-tokens#342145ff8044b58b967186b0efe34477e1f7c3ca"
   dependencies:
     svg2vectordrawable "^2.9.1"
 


### PR DESCRIPTION
This pull request lays the foundation for forms in Compound.

It creates a thin wrapper around [Radix UI Forms](https://www.radix-ui.com/docs/primitives/components/form) and aims at re-using the primitives it exposes but also set the UI we want as well as the a11y attributes we're interested in

Figma spec: https://www.figma.com/file/HUysJAhv6cK6p1Pc81Fxaa/Matrix-Authentication-Service-(MAS)?node-id=101-16968&t=ld4mSXISz6Jt6t6f-0


This is a work in progress, here's a non comprehensive list of things that are not yet tackled

- The message components awaiting implementation of https://github.com/vector-im/compound-web/pull/6
- Only input controls are supported
- Missing the whole spacing and layout of components when they're living next to each other