### PR TITLE
Add Cloudflare Pages headers file

### DIFF
--- a/res/_headers
+++ b/res/_headers
@@ -1,0 +1,3 @@
+# Remove the ACAO header which is added by default on Cloudflare Pages
+/*
+  ! Access-Control-Allow-Origin


### PR DESCRIPTION
Disable the default behaviour of adding access-control-allow-origin: * to pages sites
