### PR TITLE
Switch to graphemer to split strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-storybook": "^0.6.13",
     "jsdom": "^22.1.0",
-    "lodash-es": "^4.17.21",
     "prettier": "3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-storybook": "^0.6.13",
     "jsdom": "^22.1.0",
+    "lodash-es": "^4.17.21",
     "prettier": "3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -98,8 +99,7 @@
   },
   "dependencies": {
     "@radix-ui/react-form": "^0.0.3",
-    "classnames": "^2.3.2",
-    "lodash": "^4.17.21"
+    "classnames": "^2.3.2"
   },
   "peerDependencies": {
     "@fontsource/inter": "^5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/lodash-es": "^4.17.8",
     "@types/node": "^20.4.5",
     "@types/react": "^18.2.18",
     "@types/testing-library__jest-dom": "^5.14.9",
@@ -99,7 +98,8 @@
   },
   "dependencies": {
     "@radix-ui/react-form": "^0.0.3",
-    "classnames": "^2.3.2"
+    "classnames": "^2.3.2",
+    "graphemer": "^1.4.0"
   },
   "peerDependencies": {
     "@fontsource/inter": "^5",

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -59,6 +59,15 @@ describe("Avatar", () => {
     expect(container).toHaveTextContent("🤓");
   });
 
+  it("does not split the flag emoji as first letter", () => {
+    // This was a bug in the past, because we were relying on lodash's `split`,
+    // which handles some graphemes incorrectly.
+    const { container } = render(
+      <Avatar name="🏴󠁧󠁢󠁷󠁬󠁳󠁿 John" id="@john:example.org" />,
+    );
+    expect(container).toHaveTextContent("🏴󠁧󠁢󠁷󠁬󠁳󠁿");
+  });
+
   it.each([
     ["@bob:example.org", "8"],
     ["@alice:example.org", "3"],

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { split } from "lodash-es";
+import GraphemeSplitter from "graphemer";
 
 export const MX_USERNAME_PREFIX = "@";
 export const MX_ROOM_PREFIX = "#";
@@ -36,6 +36,8 @@ export function getInitialLetter(name: string): string {
     name = name.substring(1);
   }
 
-  // rely on the grapheme cluster splitter in lodash so that we don't break apart compound emojis
-  return split(name, "", 1)[0];
+  // rely on a grapheme cluster splitter so that we don't break apart compound emojis
+  const splitter = new GraphemeSplitter();
+  const result = splitter.iterateGraphemes(name).next();
+  return result.done ? "" : result.value;
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { split } from "lodash";
+import { split } from "lodash-es";
 
 export const MX_USERNAME_PREFIX = "@";
 export const MX_ROOM_PREFIX = "#";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         "react/jsx-runtime",
         "react/jsx-dev-runtime",
         "classnames",
+        "graphemer",
         "@radix-ui/react-form",
       ],
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
         "react-dom/server",
         "react/jsx-runtime",
         "react/jsx-dev-runtime",
-        "lodash",
         "classnames",
         "@radix-ui/react-form",
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7260,6 +7260,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,14 +3434,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
-"@types/lodash-es@^4.17.8":
-  version "4.17.8"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.8.tgz#cfffd0969507830c22da18dbb20d2ca126fdaa8b"
-  integrity sha512-euY3XQcZmIzSy7YH5+Unb3b2X12Wtk54YWINBvvGQ5SmMvwb11JQskGsfkH/5HXK77Kr8GF0wkVDIxzAisWtog==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.167":
+"@types/lodash@^4.14.167":
   version "4.14.196"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.196.tgz#a7c3d6fc52d8d71328b764e28e080b4169ec7a95"
   integrity sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7253,11 +7253,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
I had a problem with consuming the ESM module in vitest.
The resulting bundle had a `import { split } from "lodash"`, which does not work because lodash is not an ESM module.
There is an alternative `lodash-es` which is an ESM module, but then using that would break some CJS environments.

`lodash`'s split function notably doesn't handle well some emoji graphemes, so instead this switches to `graphemer`

fixes vector-im/compound#196
