### PR TITLE
Add NPM release CI workflow

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,0 +1,62 @@
+name: Release npm package
+on:
+  workflow_dispatch:
+    inputs:
+      version-bump:
+        description: The scale of the version bump required for semver compatibility
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+concurrency: release
+jobs:
+  release:
+    name: "Release & Publish"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+      - name: 🧮 Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+      - name: 🔧 Set up node environment
+        uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+
+      - name: 🛠️ Setup
+        run: yarn install --pure-lockfile
+
+      - name: 👊 Bump version
+        run: |
+          yarn version --no-git-tag-version --${{ github.event.inputs.version-bump }}
+          git config --global user.name 'ElementRobot'
+          git config --global user.email 'releases@riot.im'
+          git commit -am "${{ github.event.inputs.version-bump }} version bump"
+          git push
+      - name: ⚙️ Build
+        run: |
+          yarn build
+      - name: 🚀 Publish to npm
+        id: npm-publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+
+      - name: 🧬 Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.npm-publish.outputs.version }}
+          release_name: Release ${{ steps.npm-publish.outputs.version }}
+          body: ${{ steps.npm-publish.outputs.version }} Release
+          draft: false
+          prerelease: false

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -31,6 +31,8 @@ jobs:
           cache: "yarn"
 
       - name: 🛠️ Setup
+        # When running `install` it also calls the `prepare` step which generates
+        # a build
         run: yarn install --pure-lockfile
 
       - name: 👊 Bump version
@@ -40,9 +42,6 @@ jobs:
           git config --global user.email 'releases@riot.im'
           git commit -am "${{ github.event.inputs.version-bump }} version bump"
           git push
-      - name: ⚙️ Build
-        run: |
-          yarn build
       - name: 🚀 Publish to npm
         id: npm-publish
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
@Half-Shot This should give us tagged releases like in https://github.com/matrix-org/eslint-plugin-matrix-org/releases 

Would that be enough for what you're trying to achieve?