### PR TITLE
Add interoperability for graphemer import

### DIFF
--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -21,6 +21,21 @@ export const MX_ROOM_PREFIX = "#";
 export const MX_ALIAS_PREFIX = "+";
 
 /**
+ * The CommonJS output of the graphemer package looks wrong,
+ * this is a workaround
+ * To remove when https://github.com/flmnt/graphemer/issues/11 is fixed
+ * @param value the constructor or wrapper with `default`
+ * @returns the Graphemer constructor
+ */
+function interopDefault<T>(value: T): T {
+  if ((value as unknown as { default: T }).default) {
+    return (value as unknown as { default: T }).default;
+  }
+
+  return value;
+}
+
+/**
  * returns the first (non-sigil) character of 'name',
  * converted to uppercase
  * @param {string} name
@@ -37,7 +52,7 @@ export function getInitialLetter(name: string): string {
   }
 
   // rely on a grapheme cluster splitter so that we don't break apart compound emojis
-  const splitter = new GraphemeSplitter();
+  const splitter = new (interopDefault(GraphemeSplitter))();
   const result = splitter.iterateGraphemes(name).next();
   return result.done ? "" : result.value;
 }


### PR DESCRIPTION
To work around https://github.com/flmnt/graphemer/issues/11

This will fix the failing jest tests in https://github.com/matrix-org/matrix-react-sdk/pull/11393
Runtime works because it is using the ESM module.

Thank you @sandhose for the pointer 🙇 