### PR TITLE
Remove React.Suspense from Avatar

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, beforeEach, expect, it } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { getByRole, render, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { Avatar } from "./Avatar";
@@ -82,4 +82,22 @@ describe("Avatar", () => {
       expect(container.firstChild).toHaveAttribute("data-color", colorNumber);
     },
   );
+
+  it("allows to override the Suspense cache", () => {
+    const cache: React.ComponentProps<typeof Avatar>["cache"] = {
+      __cache: new Map(),
+      read: () => true,
+    };
+
+    const { container } = render(
+      <Avatar
+        src="http://example.org/fake_image.png"
+        id="@bob:example.org"
+        name="Bob"
+        role="presentation"
+        cache={cache}
+      />,
+    );
+    expect(getByRole(container, "img")).toBeInTheDocument();
+  });
 });

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, beforeEach, expect, it } from "vitest";
-import { getByRole, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { Avatar } from "./Avatar";
@@ -41,15 +41,6 @@ describe("Avatar", () => {
   it("renders the image-less avatar", () => {
     const { asFragment } = render(<Avatar name="Bob" id="@bob:example.org" />);
     expect(asFragment()).toMatchSnapshot();
-  });
-
-  it("replaces the placeholder with the actual image", async () => {
-    const { container } = render(
-      <Avatar src="./mock.jpg" name="Bob" id="@bob:example.org" />,
-    );
-
-    expect(container).toHaveTextContent("B");
-    await waitFor(() => expect(document.querySelector("img")).not.toBeNull());
   });
 
   it("does not split emoji as first letter", () => {
@@ -82,22 +73,4 @@ describe("Avatar", () => {
       expect(container.firstChild).toHaveAttribute("data-color", colorNumber);
     },
   );
-
-  it("allows to override the Suspense cache", () => {
-    const cache: React.ComponentProps<typeof Avatar>["cache"] = {
-      __cache: new Map(),
-      read: () => true,
-    };
-
-    const { container } = render(
-      <Avatar
-        src="http://example.org/fake_image.png"
-        id="@bob:example.org"
-        name="Bob"
-        role="presentation"
-        cache={cache}
-      />,
-    );
-    expect(getByRole(container, "img")).toBeInTheDocument();
-  });
 });

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, beforeEach, expect, it } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
 
 import { Avatar } from "./Avatar";

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import classnames from "classnames";
-import React, { Suspense, forwardRef } from "react";
+import React, { forwardRef } from "react";
 import { getInitialLetter } from "../../utils/string";
 import { SuspenseImg } from "../../utils/SuspenseImg";
 import styles from "./Avatar.module.css";
@@ -63,10 +63,6 @@ type AvatarProps = (
    * Callback when the image has failed to load.
    */
   onError?: React.ComponentProps<typeof SuspenseImg>["onError"];
-  /**
-   * The React Suspense cache instance to use
-   */
-  cache?: React.ComponentProps<typeof SuspenseImg>["cache"];
 };
 
 /**
@@ -95,14 +91,10 @@ export const Avatar = forwardRef<
     size,
     style = {},
     onError,
-    cache,
     ...props
   },
   ref,
 ) {
-  const hash = useIdColorHash(id);
-  const fallbackInitial = <>{getInitialLetter(name)}</>;
-
   return React.createElement(
     shouldBeAButton(props) ? "button" : "span",
     {
@@ -112,33 +104,32 @@ export const Avatar = forwardRef<
       "aria-label": "",
       ...props,
       "data-type": type,
-      "data-color": hash,
+      "data-color": useIdColorHash(id),
       className: classnames(styles.avatar, className),
       style: {
         ...style,
         "--cpd-avatar-size": size,
       } as React.CSSProperties,
     },
-    [
-      <>
-        {!src ? (
-          fallbackInitial
-        ) : (
-          <Suspense fallback={fallbackInitial}>
-            <SuspenseImg
-              src={src}
-              className={classnames(styles.image)}
-              data-type={type}
-              style={style}
-              width={size}
-              height={size}
-              title={id}
-              onError={onError}
-              cache={cache}
-            />
-          </Suspense>
-        )}
-      </>,
-    ],
+    <React.Fragment>
+      {!src ? (
+        getInitialLetter(name)
+      ) : (
+        <img
+          loading="lazy"
+          alt=""
+          src={src}
+          crossOrigin="anonymous"
+          referrerPolicy="no-referrer"
+          className={classnames(styles.image)}
+          data-type={type}
+          style={style}
+          width={size}
+          height={size}
+          title={id}
+          onError={onError}
+        />
+      )}
+    </React.Fragment>,
   );
 });

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -63,6 +63,10 @@ type AvatarProps = (
    * Callback when the image has failed to load.
    */
   onError?: React.ComponentProps<typeof SuspenseImg>["onError"];
+  /**
+   * The React Suspense cache instance to use
+   */
+  cache?: React.ComponentProps<typeof SuspenseImg>["cache"];
 };
 
 /**
@@ -91,6 +95,7 @@ export const Avatar = forwardRef<
     size,
     style = {},
     onError,
+    cache,
     ...props
   },
   ref,
@@ -129,6 +134,7 @@ export const Avatar = forwardRef<
               height={size}
               title={id}
               onError={onError}
+              cache={cache}
             />
           </Suspense>
         )}


### PR DESCRIPTION
It creates a lot more problems than it solves on the testing side of things on downstream projects.
We should instead strive to provide UI elements and leave individual products to make their fallback strategies