### PR TITLE
Fix Avatar's `title` & `aria-label` behaviour

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -91,7 +91,6 @@ export const Avatar = forwardRef<
     size,
     style = {},
     onError,
-    title,
     ...props
   },
   ref,
@@ -101,8 +100,8 @@ export const Avatar = forwardRef<
     {
       ref,
       role: "img",
-      title: id,
-      "aria-label": "",
+      // Default the aria-label to id
+      "aria-label": id,
       ...props,
       "data-type": type,
       "data-color": useIdColorHash(id),
@@ -129,7 +128,6 @@ export const Avatar = forwardRef<
           style={style}
           width={size}
           height={size}
-          title={title}
           onError={onError}
         />
       )}

--- a/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -3,12 +3,11 @@
 exports[`Avatar > renders the image-less avatar 1`] = `
 <DocumentFragment>
   <span
-    aria-label=""
+    aria-label="@bob:example.org"
     class="_avatar_de1988 _avatar-imageless_de1988"
     data-color="8"
     data-type="round"
     role="img"
-    title="@bob:example.org"
   >
     B
   </span>


### PR DESCRIPTION
Before https://github.com/vector-im/compound-web/pull/66 `title={id}` was set on both the `button/span` and the `img` - this is super confusing for the accessibility tree. Then that PR changed the `title` on `img` to be `title` which made more sense but still set `title={id}` on the `span/button`.

Title should not be forced like this is and should be driven by the consumer, as if it already is used with a rich tooltip library then you don't want to double-up the title. Instead specifying the aria-label defaulting to id to provide a sensible name in the accessibility tree is used

For https://github.com/vector-im/element-web/issues/26055