### PR TITLE
Document a gotcha where linking this package leads to conflicting @types/react copies

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -29,7 +29,7 @@ const config: StorybookConfig = {
 
       publicDir: "res",
     };
-  }
+  },
 };
 
 export default config;

--- a/README.md
+++ b/README.md
@@ -11,10 +11,20 @@ React implementation of Compound – Element's design system – See full docume
 
 ## Commands
 
-| Command | Runs |
-| ------- | ---- |
-| `yarn dev` | Runs a local development environment |
-| `yarn test` | Tests all components |
-| `yarn lint` | Lints all components | 
-| `yarn gen:component $name` | Bootstraps a new component |
+| Command                    | Runs                                 |
+| -------------------------- | ------------------------------------ |
+| `yarn dev`                 | Runs a local development environment |
+| `yarn test`                | Tests all components                 |
+| `yarn lint`                | Lints all components                 |
+| `yarn gen:component $name` | Bootstraps a new component           |
 
+## Development
+
+If you want to work on Compound Web as a linked package within a larger React application, TypeScript might complain about there being multiple copies of @types/react in the tree. You can work around this by linking Compound Web's copy of @types/react to your application's copy:
+
+```bash
+$ cd my-application/node_modules/@types/react
+$ yarn link
+$ cd ../../../../compound-web
+$ yarn link @types/react
+```


### PR DESCRIPTION
I spent a good couple hours today struggling to `yarn link` this package in a way that wouldn't create type errors in my Element Call checkout, and feel compelled to write down my workaround somewhere that others can find it.