### PR TITLE
Include global.css in the build output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,3 +53,5 @@ export { ValidityState } from "./components/Form/ValidityState";
 
 export { useIdColorHash } from "./components/Avatar/useIdColorHash";
 export { getInitialLetter } from "./utils/string";
+
+import "./styles/global.css";


### PR DESCRIPTION
Surely you shouldn't have to manually import it from src/ in downstream projects?