### PR TITLE
Support icons on buttons

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -18,6 +18,9 @@ limitations under the License.
   border-radius: var(--cpd-radius-pill-effect);
   cursor: pointer;
   -webkit-appeareance: none;
+  display: flex;
+  align-items: center;
+  gap: var(--cpd-space-2x);
 }
 
 .button[disabled] {
@@ -31,12 +34,22 @@ limitations under the License.
 
 .button[data-size="lg"] {
   font: var(--cpd-font-body-lg-semibold);
-  padding: var(--cpd-space-3x) var(--cpd-space-10x);
+  padding: var(--cpd-space-2x) var(--cpd-space-10x);
+  min-height: var(--cpd-space-12x);
+}
+
+.button[data-size="lg"].hasIcon {
+  padding-inline-start: var(--cpd-space-9x);
 }
 
 .button[data-size="sm"] {
   font: var(--cpd-font-body-md-semibold);
   padding: var(--cpd-space-1x) var(--cpd-space-6x);
+  min-height: var(--cpd-space-9x);
+}
+
+.button[data-size="sm"].hasIcon {
+  padding-inline-start: var(--cpd-space-5x);
 }
 
 /**

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
 import { Button as ButtonComponent } from "./Button";
+import VisibilityVisibleIcon from "@vector-im/compound-design-tokens/icons/visibility-visible.svg";
 
 export default {
   title: "Button",
@@ -32,7 +33,12 @@ export default {
 } as Meta<typeof ButtonComponent>;
 
 const Template: StoryFn<typeof ButtonComponent> = (args) => (
-  <ButtonComponent {...args}>Click me!</ButtonComponent>
+  <div style={{ display: "flex", gap: 8 }}>
+    <ButtonComponent {...args}>Click me!</ButtonComponent>
+    <ButtonComponent Icon={VisibilityVisibleIcon} {...args}>
+      Click me!
+    </ButtonComponent>
+  </div>
 );
 
 export const Primary = Template.bind({});

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -18,12 +18,22 @@ import { vi, describe, it } from "vitest";
 import React from "react";
 import { getByRole, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import ChatIcon from "@vector-im/compound-design-tokens/icons/chat.svg";
 
 import { Button } from "./Button";
 
 describe("Button", () => {
   it("renders", () => {
     const { asFragment } = render(<Button kind="primary">Click me!</Button>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("accepts an icon", () => {
+    const { asFragment } = render(
+      <Button kind="primary" Icon={ChatIcon}>
+        With icon
+      </Button>,
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import classNames from "classnames";
-import React, { PropsWithChildren } from "react";
+import React, { ComponentType, PropsWithChildren } from "react";
 import styles from "./Button.module.css";
 
 type ButtonProps<C extends React.ElementType> = {
@@ -29,13 +29,17 @@ type ButtonProps<C extends React.ElementType> = {
    */
   kind?: "primary" | "secondary" | "tertiary" | "destructive"; // TODO: Refine the naming
   /**
-   * The t-shirt size of the button
+   * The t-shirt size of the button.
    */
   size?: "sm" | "lg";
   /**
    * The CSS class name.
    */
   className?: string;
+  /**
+   * An icon to display within the button.
+   */
+  Icon?: ComponentType<React.SVGAttributes<SVGElement>>;
 } & React.ComponentPropsWithoutRef<C>;
 
 /**
@@ -48,10 +52,14 @@ export const Button = <C extends React.ElementType = "button">({
   size = "lg",
   children,
   className,
+  Icon,
   ...props
 }: PropsWithChildren<ButtonProps<C>>): React.ReactElement => {
   const Component = as || "button";
-  const classes = classNames(styles.button, className);
+  const classes = classNames(styles.button, className, {
+    [styles.hasIcon]: Icon,
+  });
+  const iconSize = size === "lg" ? 24 : 20;
 
   return (
     <Component
@@ -64,6 +72,14 @@ export const Button = <C extends React.ElementType = "button">({
       role={as === "a" ? "link" : "button"}
       tabIndex={0}
     >
+      {Icon && (
+        <Icon
+          width={iconSize}
+          height={iconSize}
+          className={styles.icon}
+          aria-hidden={true}
+        />
+      )}
       {children}
     </Component>
   );

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Button > accepts an icon 1`] = `
+<DocumentFragment>
+  <button
+    class="_button_2a1efe _hasIcon_2a1efe"
+    data-kind="primary"
+    data-size="lg"
+    role="button"
+    tabindex="0"
+  >
+    <svg
+      aria-hidden="true"
+      class="_icon_2a1efe"
+      fill="currentColor"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m2.975 16.3-1.45 4.95a.936.936 0 0 0 .25 1 .936.936 0 0 0 1 .25l4.95-1.45a10.23 10.23 0 0 0 2.1.712c.717.159 1.45.238 2.2.238a9.738 9.738 0 0 0 3.9-.788 10.098 10.098 0 0 0 3.175-2.137c.9-.9 1.612-1.958 2.137-3.175a9.738 9.738 0 0 0 .788-3.9 9.738 9.738 0 0 0-.787-3.9A10.099 10.099 0 0 0 19.1 4.925c-.9-.9-1.958-1.612-3.175-2.137a9.738 9.738 0 0 0-3.9-.788 9.738 9.738 0 0 0-3.9.788A10.099 10.099 0 0 0 4.95 4.925c-.9.9-1.613 1.958-2.138 3.175a9.738 9.738 0 0 0-.787 3.9 10.179 10.179 0 0 0 .95 4.3Z"
+        fill="currentColor"
+      />
+    </svg>
+    With icon
+  </button>
+</DocumentFragment>
+`;
+
 exports[`Button > renders 1`] = `
 <DocumentFragment>
   <button


### PR DESCRIPTION
Buttons in Compound have an optional slot for an icon to go in - this adds that capability to the Button component.

![Screenshot 2023-09-07 at 00-38-18 Button - Primary ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/d96db16c-dcb2-479a-8f73-7278b5f1425c)