### PR TITLE
Fix a regression in the button alignment

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -20,6 +20,7 @@ limitations under the License.
   appearance: none;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--cpd-space-2x);
 }
 


### PR DESCRIPTION
Because of #72, the inner text of the button became left-aligned.
Before, it was center-aligned, which was important if the button was bigger than its natural size.
This fixes that.

Before:
![image](https://github.com/vector-im/compound-web/assets/1549952/efb5ba5a-0934-4d64-9c95-cfdfc6efcf08)

After:
![image](https://github.com/vector-im/compound-web/assets/1549952/d70b2ba0-1ad5-49d6-9e1c-bcf7cce5c4af)

No changes when the button size is its natural one:
![image](https://github.com/vector-im/compound-web/assets/1549952/4c58c7d5-e662-4b17-a864-d56503e2da79)


For the record, this affects MAS' pagination buttons:

![image](https://github.com/vector-im/compound-web/assets/1549952/95bf5f62-17ea-4b0a-8ff2-f8299babc757)
