### PR TITLE
Fix the AvatarStack component tests

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -49,7 +49,6 @@ Square.args = {
 export const Button = Template.bind({});
 Button.args = {
   type: "round",
-  as: "button",
   onClick: () => console.log("clicked!"),
 };
 

--- a/src/components/Avatar/AvatarStack.test.tsx
+++ b/src/components/Avatar/AvatarStack.test.tsx
@@ -19,6 +19,7 @@ import { render } from "@testing-library/react";
 import React from "react";
 
 import { AvatarStack } from "./AvatarStack";
+import { Avatar } from "./Avatar";
 
 const originalImage = global.Image;
 
@@ -45,18 +46,49 @@ describe("AvatarStack", () => {
 
   it("renders", () => {
     const { asFragment } = render(
-      <AvatarStack avatars={avatars} size="32px" />,
+      <AvatarStack>
+        {avatars.map((avatar) => (
+          <Avatar
+            name={avatar.name}
+            id={avatar.id}
+            key={avatar.id}
+            size="32px"
+          />
+        ))}
+      </AvatarStack>,
     );
     expect(asFragment()).toMatchSnapshot();
   });
 
   it("adds the mask to the body", () => {
-    render(<AvatarStack avatars={avatars} size="32px" />);
+    render(
+      <AvatarStack>
+        {avatars.map((avatar) => (
+          <Avatar
+            name={avatar.name}
+            id={avatar.id}
+            key={avatar.id}
+            size="32px"
+          />
+        ))}
+      </AvatarStack>,
+    );
 
     // We can't run better assertions as `SVG` loading is mocked out in jest
     expect(document.querySelectorAll("svg")).toHaveLength(1);
 
-    render(<AvatarStack avatars={avatars} size="32px" />);
+    render(
+      <AvatarStack>
+        {avatars.map((avatar) => (
+          <Avatar
+            name={avatar.name}
+            id={avatar.id}
+            key={avatar.id}
+            size="32px"
+          />
+        ))}
+      </AvatarStack>,
+    );
 
     // We only one instance of the mask, ever!
     expect(document.querySelectorAll("svg")).toHaveLength(1);

--- a/src/components/Avatar/__snapshots__/AvatarStack.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/AvatarStack.test.tsx.snap
@@ -4,6 +4,27 @@ exports[`AvatarStack > renders 1`] = `
 <DocumentFragment>
   <div
     class="_stacked-avatars_de1988"
-  />
+  >
+    <span
+      aria-label="@alice:example.org"
+      class="_avatar_de1988 _avatar-imageless_de1988"
+      data-color="3"
+      data-type="round"
+      role="img"
+      style="--cpd-avatar-size: 32px;"
+    >
+      A
+    </span>
+    <span
+      aria-label="@bob:example.org"
+      class="_avatar_de1988 _avatar-imageless_de1988"
+      data-color="8"
+      data-type="round"
+      role="img"
+      style="--cpd-avatar-size: 32px;"
+    >
+      B
+    </span>
+  </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
The tests were just wrong. The test files were not typechecking correctly, which apparently we don't do as part of linting?
