### PR TITLE
Fix some button sizing discrepancies

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,13 +2,16 @@
   "extends": "stylelint-config-standard",
   "plugins": ["stylelint-value-no-unknown-custom-properties"],
   "rules": {
-    "csstools/value-no-unknown-custom-properties": [true, {
-      "importFrom": [
-        "./src/styles/global.css",
-        "./node_modules/@vector-im/compound-design-tokens/assets/web/css/cpd-common.css",
-        "./node_modules/@vector-im/compound-design-tokens/assets/web/css/cpd-light-mq.css"
-      ]
-    }]
+    "csstools/value-no-unknown-custom-properties": [
+      true,
+      {
+        "importFrom": [
+          "./src/styles/global.css",
+          "./node_modules/@vector-im/compound-design-tokens/assets/web/css/cpd-common.css",
+          "./node_modules/@vector-im/compound-design-tokens/assets/web/css/cpd-light-mq.css"
+        ]
+      }
+    ]
   },
   "ignoreFiles": ["dist/**/*.css"]
 }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -22,6 +22,7 @@ limitations under the License.
   align-items: center;
   justify-content: center;
   gap: var(--cpd-space-2x);
+  box-sizing: border-box;
 }
 
 .button[disabled] {
@@ -35,18 +36,20 @@ limitations under the License.
 
 .button[data-size="lg"] {
   font: var(--cpd-font-body-lg-semibold);
-  padding: var(--cpd-space-2x) var(--cpd-space-10x);
-  min-height: var(--cpd-space-12x);
+  padding-block: var(--cpd-space-2x);
+  padding-inline: var(--cpd-space-8x);
+  min-block-size: var(--cpd-space-12x);
 }
 
 .button[data-size="lg"].has-icon {
-  padding-inline-start: var(--cpd-space-9x);
+  padding-inline-start: var(--cpd-space-7x);
 }
 
 .button[data-size="sm"] {
   font: var(--cpd-font-body-md-semibold);
-  padding: var(--cpd-space-1x) var(--cpd-space-6x);
-  min-height: var(--cpd-space-9x);
+  padding-block: var(--cpd-space-1x);
+  padding-inline: var(--cpd-space-6x);
+  min-block-size: var(--cpd-space-9x);
 }
 
 .button[data-size="sm"].has-icon {


### PR DESCRIPTION
They had too much inline padding, and secondary buttons had the border adding 2px to their height. Also, setting an explicit box-sizing value turns out to be important, or else they could inherit the wrong value in certain environments (like the Storybook, as seen below).

.|Before|After
-|-|-
Small|![Screenshot 2023-09-18 at 13-58-51 Button - Secondary ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/93172752-028e-45f1-8d0b-8e2fb4b54dde)|![Screenshot 2023-09-18 at 13-42-59 Button - Secondary ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/a34dc9a7-7780-447b-909e-8d76f5de6d8f)
Large|![Screenshot 2023-09-18 at 13-58-58 Button - Secondary ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/d6eeda94-cd32-4e1e-a269-38ea00e6b519)|![Screenshot 2023-09-18 at 13-43-11 Button - Secondary ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/60537e1e-2cb6-411d-a6d8-956d68e3ebf3)