### PR TITLE
Ponyfill useId

### DIFF
--- a/src/components/ActionControl/ActionControl.tsx
+++ b/src/components/ActionControl/ActionControl.tsx
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 import classnames from "classnames";
-import React, { PropsWithChildren, useId, forwardRef } from "react";
+import React, { PropsWithChildren, forwardRef } from "react";
 import styles from "./ActionControl.module.css";
 
 import { Control, Field, Root } from "../Form";
+import useId from "../../utils/useId";
 
 type ActionControlProps = {
   /**

--- a/src/utils/useId.ts
+++ b/src/utils/useId.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 const react18UseId = (React as { useId?: () => string }).useId;
 
@@ -11,6 +11,6 @@ const useIdPonyFill = (): string => {
   return React.useMemo(getUniqueId, []);
 };
 
-const useId = (typeof react18UseId === "function") ? react18UseId : useIdPonyFill;
+const useId = typeof react18UseId === "function" ? react18UseId : useIdPonyFill;
 
 export default useId;

--- a/src/utils/useId.ts
+++ b/src/utils/useId.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+const react18UseId = (React as { useId?: () => string }).useId;
+
+const getUniqueId = (() => {
+  let index = 1;
+  return () => `:r${index++}:`;
+})();
+
+const useIdPonyFill = (): string => {
+  return React.useMemo(getUniqueId, []);
+};
+
+const useId = (typeof react18UseId === "function") ? react18UseId : useIdPonyFill;
+
+export default useId;


### PR DESCRIPTION
Inspired by https://github.com/ezcater/recipe/blob/dc253df74f0b9c509f13172980eb8c1a0defb62a/packages/recipe/src/utils/hooks/useUniqueId.ts.

Fixes: vector-im/compound#224