### PR TITLE
Prevent useId import from React and fix another occurrence

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,13 +18,19 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "no-restricted-imports": ["error", {
-      "paths": [{
-        "name": "react",
-        "importNames": ["useId"],
-        "message": "'useId' is only available in React 18. Please use the ponyfill from 'utils/useId' instead."
-      }],
-    }],
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "react",
+            importNames: ["useId"],
+            message:
+              "'useId' is only available in React 18. Please use the ponyfill from 'utils/useId' instead.",
+          },
+        ],
+      },
+    ],
     "prettier/prettier": "error",
   },
   plugins: ["prettier", "react", "@typescript-eslint", "matrix-org"],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,13 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
+    "no-restricted-imports": ["error", {
+      "paths": [{
+        "name": "react",
+        "importNames": ["useId"],
+        "message": "'useId' is only available in React 18. Please use the ponyfill from 'utils/useId' instead."
+      }],
+    }],
     "prettier/prettier": "error",
   },
   plugins: ["prettier", "react", "@typescript-eslint", "matrix-org"],

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 import classnames from "classnames";
-import React, { useId } from "react";
+import React from "react";
 import styles from "./Search.module.css";
 import { Field, Label } from "../Form";
 
 import SearchIcon from "@vector-im/compound-design-tokens/icons/search.svg";
+import useId from "../../utils/useId";
 
 type SearchProps = {
   /**

--- a/src/utils/useId.ts
+++ b/src/utils/useId.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// eslint-disable-next-line no-restricted-imports
 import * as React from "react";
 
 const react18UseId = (React as { useId?: () => string }).useId;


### PR DESCRIPTION
Looks like another case has slipped in since adding the ponyfill. So definitely good to prevent via eslint.

Fixes: vector-im/compound#228