### PR TITLE
Form: implement read-only state on controls and make the help text better

### DIFF
--- a/src/components/ActionControl/ActionControl.module.css
+++ b/src/components/ActionControl/ActionControl.module.css
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 .actioncontrol {
-  max-inline-size: fit-content;
   position: relative;
+  display: inline-flex;
 }
 
 input.input {
+  flex: 1;
   padding-inline-end: var(--cpd-space-12x);
 }
 

--- a/src/components/ActionControl/ActionControl.stories.tsx
+++ b/src/components/ActionControl/ActionControl.stories.tsx
@@ -17,23 +17,23 @@ limitations under the License.
 import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
-import { StandaloneActionControl as StandaloneActionControl } from "./ActionControl";
+import { ActionControl } from "./ActionControl";
 import { Field, Root } from "../Form";
 import ThreadIcon from "../Icon/icons/thread.svg";
 
 export default {
   title: "ActionControl",
-  component: StandaloneActionControl,
+  component: ActionControl,
   argTypes: {},
   args: {
     Icon: ThreadIcon,
   },
-} as Meta<typeof StandaloneActionControl>;
+} as Meta<typeof ActionControl>;
 
-const Template: StoryFn<typeof StandaloneActionControl> = (args) => (
+const Template: StoryFn<typeof ActionControl> = (args) => (
   <Root>
     <Field name="action">
-      <StandaloneActionControl {...args} />
+      <ActionControl {...args} />
     </Field>
   </Root>
 );

--- a/src/components/ActionControl/ActionControl.tsx
+++ b/src/components/ActionControl/ActionControl.tsx
@@ -57,14 +57,7 @@ export const ActionControl = forwardRef<
   const classes = classnames(styles.actioncontrol, className);
   return (
     <div className={classes}>
-      <Control
-        ref={ref}
-        {...props}
-        className={styles.input}
-        id={id}
-        autoComplete="off"
-        autoCorrect="off"
-      >
+      <Control ref={ref} {...props} className={styles.input} id={id}>
         {children}
       </Control>
       <Icon

--- a/src/components/Form/Control.stories.tsx
+++ b/src/components/Form/Control.stories.tsx
@@ -123,7 +123,19 @@ export const Focus: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await canvas.getByRole("textbox").focus();
+    const input = canvas.getByRole("textbox") as HTMLInputElement;
+    input.focus();
+
+    // Wait for the next tick
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Add an identifier post interactions is complete
+    input.classList.add("percy-selector-placeholder");
+  },
+  parameters: {
+    percy: {
+      waitForSelector: ".percy-selector-placeholder",
+    },
   },
 };
 
@@ -141,5 +153,13 @@ export const Invalid: Story = {
     await new Promise((resolve) => setTimeout(resolve, 0));
     // radix-ui always focuses the input when invalid, which is not what we want for snapshots
     input.blur();
+
+    // Add an identifier post interactions is complete
+    input.classList.add("percy-selector-placeholder");
+  },
+  parameters: {
+    percy: {
+      waitForSelector: ".percy-selector-placeholder",
+    },
   },
 };

--- a/src/components/Form/Control.stories.tsx
+++ b/src/components/Form/Control.stories.tsx
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from "react";
+
+import { Meta, StoryObj } from "@storybook/react";
+import { within } from "@storybook/testing-library";
+
+import * as Form from "./index";
+
+type Props = React.ComponentProps<typeof Form.Control> & {
+  label?: string;
+  invalid?: boolean;
+  message?: string;
+};
+
+export default {
+  title: "Control",
+  component: Form.Control,
+  render: ({ label, invalid, message, ...props }) => (
+    <Form.Root>
+      <Form.Field name="story" serverInvalid={invalid}>
+        {label && <Form.Label>{label}</Form.Label>}
+        <Form.Control {...props} />
+        {message && (
+          <Form.Message kind={invalid ? "error" : "help"}>
+            {message}
+          </Form.Message>
+        )}
+      </Form.Field>
+    </Form.Root>
+  ),
+  parameters: {
+    controls: {
+      include: [
+        "value",
+        "placeholder",
+        "disabled",
+        "readOnly",
+        "label",
+        "invalid",
+        "message",
+      ],
+    },
+  },
+  argTypes: {
+    value: {
+      type: "string",
+    },
+    placeholder: {
+      type: "string",
+    },
+    disabled: {
+      type: "boolean",
+    },
+    readOnly: {
+      type: "boolean",
+    },
+    label: {
+      type: "string",
+    },
+    invalid: {
+      type: "boolean",
+    },
+    message: {
+      type: "string",
+    },
+  },
+  args: {
+    placeholder: "",
+    disabled: false,
+    readOnly: false,
+    invalid: false,
+    message: "Help text.",
+  },
+} satisfies Meta<Props>;
+
+type Story = StoryObj<Props>;
+
+export const Basic: Story = {
+  args: {
+    label: "Basic",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    (canvas.getByRole("textbox") as HTMLInputElement).value = "Basic";
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: "Disabled",
+    value: "Disabled",
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    label: "Read only",
+    value: "Read only",
+    readOnly: true,
+  },
+};
+
+export const Focus: Story = {
+  args: {
+    label: "Focus",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.getByRole("textbox").focus();
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    label: "Invalid",
+    invalid: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox") as HTMLInputElement;
+    input.value = "Invalid";
+
+    // Wait for the next tick
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // radix-ui always focuses the input when invalid, which is not what we want for snapshots
+    input.blur();
+  },
+};

--- a/src/components/Form/Message.tsx
+++ b/src/components/Form/Message.tsx
@@ -19,12 +19,20 @@ import { Message as RadixMessage } from "@radix-ui/react-form";
 
 import styles from "./form.module.css";
 import classNames from "classnames";
+import ErrorIcon from "@vector-im/compound-design-tokens/icons/error.svg";
 
 type MessageProps = {
   /**
    * The CSS class name.
    */
   className?: string;
+
+  /**
+   * The kind of the form, either "help" or "error".
+   *
+   * @default "help"
+   */
+  kind?: "help" | "error";
 } & React.ComponentProps<typeof RadixMessage>;
 
 /**
@@ -34,12 +42,16 @@ type MessageProps = {
 export const Message = forwardRef<
   HTMLSpanElement,
   PropsWithChildren<MessageProps>
->(function Message({ children, ...props }, ref) {
+>(function Message({ children, kind = "help", ...props }, ref) {
   const classes = classNames(styles.message, props.className);
   return (
-    <RadixMessage ref={ref} {...props} className={classes}>
-      {/* Pending to be replaced by the alert component, see
-          https://github.com/vector-im/compound-web/pull/6 */}
+    <RadixMessage
+      ref={ref}
+      {...props}
+      className={classes}
+      data-invalid={kind == "error" ? true : undefined}
+    >
+      {kind == "error" && <ErrorIcon />}
       {children}
     </RadixMessage>
   );

--- a/src/components/Form/form.module.css
+++ b/src/components/Form/form.module.css
@@ -39,7 +39,9 @@ limitations under the License.
  */
 
 .label {
-  font-weight: var(--cpd-font-weight-medium);
+  font: var(--cpd-font-body-md-medium);
+  letter-spacing: var(--cpd-font-letter-spacing-body-md);
+  margin-block-end: var(--cpd-space-1x);
 }
 
 .label[for] {
@@ -55,6 +57,36 @@ https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility */
 .label:has(~ .control[disabled]) {
   color: var(--cpd-color-text-disabled);
   cursor: not-allowed;
+}
+
+/**
+ * MESSAGE
+ */
+
+.message {
+  color: var(--cpd-color-text-secondary);
+  font: var(--cpd-font-body-sm-regular);
+  letter-spacing: var(--cpd-font-letter-spacing-body-sm);
+  margin-block-start: var(--cpd-space-2x);
+}
+
+.message[data-invalid] {
+  color: var(--cpd-color-text-critical-primary);
+}
+
+.control[disabled] ~ .message {
+  color: var(--cpd-color-text-disabled);
+  cursor: not-allowed;
+}
+
+.message > svg {
+  display: inline-block;
+  vertical-align: bottom;
+  margin-inline-end: var(--cpd-space-2x);
+
+  /* Calculate the size of the icon based on the font size and line height */
+  block-size: calc(1em * var(--cpd-font-line-height-regular));
+  inline-size: calc(1em * var(--cpd-font-line-height-regular));
 }
 
 /**
@@ -102,5 +134,13 @@ input:disabled ~ .control {
   background: var(--cpd-color-bg-canvas-disabled);
   border-color: var(--cpd-color-border-disabled);
   color: var(--cpd-color-text-disabled);
+  cursor: not-allowed;
+}
+
+.control[readonly],
+input[readonly] ~ .control {
+  background: var(--cpd-color-bg-subtle-secondary);
+  border-color: var(--cpd-color-bg-subtle-secondary);
+  color: var(--cpd-color-text-secondary);
   cursor: not-allowed;
 }

--- a/src/components/Form/form.module.css
+++ b/src/components/Form/form.module.css
@@ -21,6 +21,9 @@ limitations under the License.
  */
 
 .root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-5x);
   font: var(--cpd-font-body-md-regular);
   letter-spacing: var(--cpd-font-letter-spacing-body-md);
 }

--- a/src/components/Form/form.module.css
+++ b/src/components/Form/form.module.css
@@ -142,5 +142,4 @@ input[readonly] ~ .control {
   background: var(--cpd-color-bg-subtle-secondary);
   border-color: var(--cpd-color-bg-subtle-secondary);
   color: var(--cpd-color-text-secondary);
-  cursor: not-allowed;
 }


### PR DESCRIPTION
This implements the `readonly` state on inputs as seen in MAS designs: https://www.figma.com/file/HUysJAhv6cK6p1Pc81Fxaa/Matrix-Authentication-Service-(MAS)?type=design&node-id=3464-13893&mode=dev

I also polished a bit the form controls, including:

 - fix the margin between the label and the field
 - made the label use the right font
 - made the help text use the right font, color and margin
 - added a `kind="error"|"help"` prop on `<Form.Message />` component, with a warning icon when `kind == "error"`
 - added a story for a single input with the right controls (and hopefully the right percy snapshots)

Please check out the stories here: https://quenting-readonly-control.compound-web.pages.dev/?path=/story/control--basic