### PR TITLE
Fix class name mismatch in Tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -26,7 +26,7 @@ limitations under the License.
   text-align: center;
 }
 
-.shortcut {
+.caption {
   font-weight: var(--cpd-font-weight-regular);
   color: var(--cpd-color-text-secondary);
 }


### PR DESCRIPTION
Caused by https://github.com/vector-im/compound-web/pull/103

![image](https://github.com/vector-im/compound-web/assets/2403652/4d6833ee-a196-44bc-a6cf-65afd3ddbfba)
