### PR TITLE
Storybook: enable autodocs

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,10 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/!(__ComponentTemplate__)*.stories.@(js|jsx|ts|tsx)"],
+  stories: [
+    "../src/**/*.mdx",
+    "../src/**/!(__ComponentTemplate__)*.stories.@(js|jsx|ts|tsx)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,9 +16,6 @@ const config: StorybookConfig = {
   features: {
     storyStoreV7: true,
   },
-  docs: {
-    autodocs: false,
-  },
   viteFinal: (config) => {
     return {
       ...config,

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/**/*.mdx", "../src/**/!(__ComponentTemplate__)*.stories.@(js|jsx|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Alert as AlertComponent } from "./Alert";
 
 export default {
   title: "Alert",
   component: AlertComponent,
+  tags: ["autodocs"],
   argTypes: {
     type: {
       options: ["success", "critical", "info"],
@@ -29,29 +29,36 @@ export default {
     },
   },
   args: {
+    title: "Title",
+    children: "Description",
     onClose: () => {
       console.log("Clicked!");
     },
   },
 } as Meta<typeof AlertComponent>;
 
-const Template: StoryFn<typeof AlertComponent> = (args) => (
-  <AlertComponent {...args} title="Title">
-    Description
-  </AlertComponent>
-);
-
-export const Success = Template.bind({});
-Success.args = {
-  type: "success",
+export const Success = {
+  args: {
+    type: "success",
+  },
 };
 
-export const Critical = Template.bind({});
-Critical.args = {
-  type: "critical",
+export const Critical = {
+  args: {
+    type: "critical",
+  },
 };
 
-export const Info = Template.bind({});
-Info.args = {
-  type: "info",
+export const Info = {
+  args: {
+    type: "info",
+  },
+};
+
+export const WithoutClose = {
+  ...Success,
+  args: {
+    ...Success.args,
+    onClose: undefined,
+  },
 };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -22,6 +22,7 @@ import { Avatar as AvatarComponent } from "./Avatar";
 export default {
   title: "Avatar",
   component: AvatarComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {
     name: "Bob",
@@ -29,6 +30,10 @@ export default {
     id: "@bob:example.org",
     src: "/images/__test__/kitten.jpg",
     type: "round",
+  },
+  design: {
+    type: "figma",
+    url: "https://www.figma.com/file/rTaQE2nIUSLav4Tg3nozq7/Compound-Web-Components?type=design&node-id=522-742&mode=dev",
   },
 } as Meta<typeof AvatarComponent>;
 

--- a/src/components/Avatar/AvatarStack.stories.tsx
+++ b/src/components/Avatar/AvatarStack.stories.tsx
@@ -21,8 +21,9 @@ import { AvatarStack as AvatarStackComponent } from "./AvatarStack";
 import { Avatar } from "./Avatar";
 
 export default {
-  title: "StackedAvatar",
+  title: "Avatar/StackedAvatar",
   component: AvatarStackComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {
     size: "64px",

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -28,6 +28,7 @@ type Props = {
 export default {
   title: "Button",
   component: ButtonComponent,
+  tags: ["autodocs"],
   argTypes: {
     size: {
       options: ["sm", "lg"],

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -14,40 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 
-import { Checkbox as CheckboxComponent } from "./Checkbox";
+import { Checkbox } from "./Checkbox";
 
 export default {
   title: "Checkbox",
-  component: CheckboxComponent,
+  component: Checkbox,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
-} as Meta<typeof CheckboxComponent>;
+} as Meta<typeof Checkbox>;
 
-const Template: StoryFn<typeof CheckboxComponent> = (args) => (
-  <CheckboxComponent {...args} />
-);
-
-export const Primary = Template.bind({});
-Primary.args = {};
-Primary.parameters = {};
-
-export const Critical = Template.bind({});
-Critical.args = {
-  kind: "critical",
-};
-Critical.parameters = {};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
-  checked: false,
+export const Primary: StoryObj = {
+  args: {},
 };
 
-export const DisabledChecked = Template.bind({});
-DisabledChecked.args = {
-  disabled: true,
-  checked: true,
+export const Critical: StoryObj = {
+  args: {
+    kind: "critical",
+  },
+};
+
+export const Disabled: StoryObj = {
+  args: {
+    disabled: true,
+    checked: false,
+  },
+};
+
+export const DisabledChecked: StoryObj = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
 };

--- a/src/components/Glass/Glass.stories.tsx
+++ b/src/components/Glass/Glass.stories.tsx
@@ -23,6 +23,7 @@ import { Text } from "../Typography/Text";
 export default {
   title: "Glass",
   component: GlassComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof GlassComponent>;

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -22,8 +22,9 @@ import { IconButton as IconButtonComponent } from "./IconButton";
 import UserIcon from "@vector-im/compound-design-tokens/icons/user-profile.svg";
 
 export default {
-  title: "IconButton",
+  title: "Button/IconButton",
   component: IconButtonComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof IconButtonComponent>;

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -22,6 +22,7 @@ import { Link as LinkComponent } from "./Link";
 export default {
   title: "Link",
   component: LinkComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof LinkComponent>;

--- a/src/components/MenuItem/MenuItem.stories.tsx
+++ b/src/components/MenuItem/MenuItem.stories.tsx
@@ -26,6 +26,7 @@ import { Text } from "../Typography/Text";
 export default {
   title: "MenuItem",
   component: MenuItemComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof MenuItemComponent>;

--- a/src/components/MenuItem/ToggleMenuItem.stories.tsx
+++ b/src/components/MenuItem/ToggleMenuItem.stories.tsx
@@ -24,6 +24,7 @@ import { ToggleMenuItem as ToggleMenuItemComponent } from "./ToggleMenuItem";
 export default {
   title: "ToggleMenuItem",
   component: ToggleMenuItemComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof ToggleMenuItemComponent>;

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -14,28 +14,56 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Radio as RadioComponent } from "./Radio";
 
 export default {
   title: "Radio",
   component: RadioComponent,
-  argTypes: {},
-  args: {},
+  tags: ["autodocs"],
+  args: {
+    checked: false,
+    disabled: false,
+    kind: "primary",
+  },
 } as Meta<typeof RadioComponent>;
 
-const Template: StoryFn<typeof RadioComponent> = (args) => (
-  <RadioComponent {...args} />
-);
+export const Primary = {};
 
-export const Primary = Template.bind({});
-Primary.args = {};
-Primary.parameters = {};
-
-export const Critical = Template.bind({});
-Critical.args = {
-  kind: "critical",
+export const Checked = {
+  ...Primary,
+  args: {
+    checked: true,
+  },
 };
-Critical.parameters = {};
+
+export const CheckedDisabled = {
+  ...Checked,
+  args: {
+    ...Checked.args,
+    disabled: true,
+  },
+};
+
+export const Critical = {
+  args: {
+    kind: "critical",
+  },
+};
+
+export const CriticalChecked = {
+  ...Critical,
+  args: {
+    ...Critical.args,
+    checked: true,
+  },
+};
+
+export const CriticalCheckedDisabled = {
+  ...CriticalChecked,
+  args: {
+    ...CriticalChecked.args,
+    disabled: true,
+  },
+};

--- a/src/components/Search/Search.stories.tsx
+++ b/src/components/Search/Search.stories.tsx
@@ -23,6 +23,7 @@ import { Form } from "@radix-ui/react-form";
 export default {
   title: "Search",
   component: SearchComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof SearchComponent>;

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -14,28 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Toggle as ToggleComponent } from "./Toggle";
 
 export default {
   title: "Toggle",
   component: ToggleComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof ToggleComponent>;
 
-const Template: StoryFn<typeof ToggleComponent> = (args) => (
-  <>
-    <ToggleComponent {...args} checked={false} />
-    <br />
-    <ToggleComponent {...args} checked={true} />
-  </>
-);
+export const Active = {
+  args: {
+    checked: false,
+  },
+};
 
-export const Active = Template.bind({});
-Active.args = {};
+export const Checked = {
+  args: {
+    checked: true,
+  },
+};
 
-export const Disabled = Template.bind({});
-Disabled.args = { disabled: true };
+export const Disabled = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledChecked = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -25,6 +25,7 @@ import UserIcon from "@vector-im/compound-design-tokens/icons/user-profile.svg";
 export default {
   title: "Tooltip",
   component: TooltipComponent,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
 } as Meta<typeof TooltipComponent>;

--- a/src/components/Typography/Heading.stories.tsx
+++ b/src/components/Typography/Heading.stories.tsx
@@ -23,13 +23,15 @@ import { Heading as HeadingComponent } from "./Heading";
 export default {
   title: "Typography",
   component: HeadingComponent,
-  size: {
-    options: ["xs", "sm", "md", "lg"],
-    control: { type: "inline-radio" },
-  },
-  weight: {
-    options: ["regular", "medium", "semibold"],
-    control: { type: "inline-radio" },
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "inline-radio" },
+    },
+    weight: {
+      options: ["regular", "medium", "semibold"],
+      control: { type: "inline-radio" },
+    },
   },
 } as Meta<typeof HeadingComponent>;
 

--- a/src/utils/__ComponentTemplate__/__ComponentTemplate__.stories.tsx
+++ b/src/utils/__ComponentTemplate__/__ComponentTemplate__.stories.tsx
@@ -14,27 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { __ComponentTemplate__ as __ComponentTemplate__Component } from "./__ComponentTemplate__";
 
 export default {
   title: "__ComponentTemplate__",
   component: __ComponentTemplate__Component,
+  tags: ["autodocs"],
   argTypes: {},
   args: {},
-} as Meta<typeof __ComponentTemplate__Component>;
-
-const Template: StoryFn<typeof __ComponentTemplate__Component> = (args) => (
-  <__ComponentTemplate__Component {...args} />
-);
-
-export const Round = Template.bind({});
-Round.args = {};
-Round.parameters = {
   design: {
     type: "figma",
     url: "%FIGMA_URL%",
   },
+} as Meta<typeof __ComponentTemplate__Component>;
+
+export const Default = {
+  args: {},
+  parameters: {},
 };


### PR DESCRIPTION
Various tweaks and improvements to storybook

- Set autodocs to the default behaviour (enabled where `tags` includes `autodocs`)
- Nest `AvatarStack` inside `Avatar` in story hierarchy
- Nest `IconButton` inside `Button` in story hierarchy
- Exclude the stories template from storybook build
- Add more variations to some stories