### PR TITLE
Update button styles

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -23,6 +23,7 @@ limitations under the License.
   justify-content: center;
   gap: var(--cpd-space-2x);
   box-sizing: border-box;
+  font: var(--cpd-font-body-md-semibold);
 }
 
 .button[disabled] {
@@ -35,7 +36,6 @@ limitations under the License.
  */
 
 .button[data-size="lg"] {
-  font: var(--cpd-font-body-lg-semibold);
   padding-block: var(--cpd-space-2x);
   padding-inline: var(--cpd-space-8x);
   min-block-size: var(--cpd-space-12x);
@@ -46,7 +46,6 @@ limitations under the License.
 }
 
 .button[data-size="sm"] {
-  font: var(--cpd-font-body-md-semibold);
   padding-block: var(--cpd-space-1x);
   padding-inline: var(--cpd-space-6x);
   min-block-size: var(--cpd-space-9x);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -75,7 +75,6 @@ export const Button = forwardRef(function Button<
   const classes = classNames(styles.button, className, {
     [styles["has-icon"]]: Icon,
   });
-  const iconSize = size === "lg" ? 24 : 20;
 
   return (
     <Component
@@ -91,8 +90,8 @@ export const Button = forwardRef(function Button<
     >
       {Icon && (
         <Icon
-          width={iconSize}
-          height={iconSize}
+          width={20}
+          height={20}
           className={styles.icon}
           aria-hidden={true}
         />

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -13,9 +13,9 @@ exports[`Button > accepts an icon 1`] = `
       aria-hidden="true"
       class="_icon_2a1efe"
       fill="none"
-      height="24"
+      height="20"
       viewBox="0 0 24 24"
-      width="24"
+      width="20"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
[Design specs](https://www.figma.com/file/rTaQE2nIUSLav4Tg3nozq7/Compound-Web-Components?type=design&node-id=636-4&mode=dev)

Buttons have been updated in the design specs to use the same font and icon sizes in both the large and small variants.

![Screenshot 2023-10-18 at 12-59-34 Button - Docs ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/b0cc3170-989e-4732-99a2-90a98fa7d9be)
![Screenshot 2023-10-18 at 12-59-22 Button - Docs ⋅ Storybook](https://github.com/vector-im/compound-web/assets/48614497/a23cb4f3-9704-447f-a15f-90d3c4dd3605)