### PR TITLE
Create separator component

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "dependencies": {
     "@radix-ui/react-form": "^0.0.3",
+    "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.6",
     "classnames": "^2.3.2",
     "graphemer": "^1.4.0"

--- a/src/components/Separator/Separator.module.css
+++ b/src/components/Separator/Separator.module.css
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.separator {
+  --cpd-separator-spacing: var(--cpd-space-2x);
+
+  background-color: var(--cpd-color-gray-400);
+}
+
+.separator[data-orientation="horizontal"] {
+  margin-block: var(--cpd-separator-spacing);
+  block-size: 1px;
+  inline-size: 100%;
+}
+
+.separator[data-orientation="vertical"] {
+  margin-inline: var(--cpd-separator-spacing);
+  block-size: 100%;
+  inline-size: 1px;
+}

--- a/src/components/Separator/Separator.stories.tsx
+++ b/src/components/Separator/Separator.stories.tsx
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Meta } from "@storybook/react";
+
+import { Separator as SeparatorComponent } from "./Separator";
+
+export default {
+  title: "Separator",
+  component: SeparatorComponent,
+  tags: ["autodocs"],
+  argTypes: {},
+  args: {},
+} as Meta<typeof SeparatorComponent>;
+
+export const Default = {
+  args: {},
+  parameters: {},
+};

--- a/src/components/Separator/Separator.test.tsx
+++ b/src/components/Separator/Separator.test.tsx
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+import { Separator } from "./Separator";
+
+describe("Separator", () => {
+  it("renders", () => {
+    const { asFragment } = render(<Separator />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/Separator/Separator.tsx
+++ b/src/components/Separator/Separator.tsx
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import classnames from "classnames";
+import * as RadixSeparator from "@radix-ui/react-separator";
+import React, {
+  ComponentProps,
+  PropsWithoutRef,
+  Ref,
+  forwardRef,
+  useEffect,
+} from "react";
+import styles from "./Separator.module.css";
+
+type SeparatorProps = {
+  /**
+   * The CSS class name.
+   */
+  className?: string;
+  /**
+   * The spacing on either side of the separator
+   */
+  spacing?: string;
+} & ComponentProps<typeof RadixSeparator.Root>;
+
+const SPACING_CUSTOM_PROP = "--cpd-separator-spacing";
+
+export const Separator = forwardRef(
+  (
+    {
+      className,
+      spacing = "var(--cpd-space-2x)",
+      ...props
+    }: PropsWithoutRef<SeparatorProps>,
+    ref?: Ref<HTMLDivElement>,
+  ) => {
+    const classes = classnames(styles.separator, className);
+
+    useEffect(() => {
+      // Casting to `RefObject` as everything here should use this type.
+      // Functions refs are not something we wish to support and string refs
+      // are already unsupported with `forwardRef`.
+      const style = (ref as React.RefObject<HTMLDivElement>)?.current?.style;
+      if (spacing) {
+        style?.setProperty(SPACING_CUSTOM_PROP, spacing);
+      } else {
+        style?.removeProperty(SPACING_CUSTOM_PROP);
+      }
+    }, [spacing]);
+
+    return <RadixSeparator.Root {...props} className={classes} ref={ref} />;
+  },
+);
+
+Separator.displayName = "Separator";

--- a/src/components/Separator/Separator.tsx
+++ b/src/components/Separator/Separator.tsx
@@ -38,6 +38,10 @@ type SeparatorProps = {
 
 const SPACING_CUSTOM_PROP = "--cpd-separator-spacing";
 
+/**
+ * A separator component
+ * Note: Only supports `React.RefObject`
+ */
 export const Separator = forwardRef(
   (
     {

--- a/src/components/Separator/__snapshots__/Separator.test.tsx.snap
+++ b/src/components/Separator/__snapshots__/Separator.test.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Separator > renders 1`] = `
+<DocumentFragment>
+  <div
+    class="_separator_162edc"
+    data-orientation="horizontal"
+    role="separator"
+  />
+</DocumentFragment>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,7 +1930,7 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.5"
 
-"@radix-ui/react-separator@1.0.3":
+"@radix-ui/react-separator@1.0.3", "@radix-ui/react-separator@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.0.3.tgz#be5a931a543d5726336b112f465f58585c04c8aa"
   integrity sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==


### PR DESCRIPTION
Initially, we'll use it just for explicit/standalone `<hr>` elements.

There are no immediate plans to replace generic borders in components with standalone, nested divider elements.