### PR TITLE
Make usage of useId unanalyzable

### DIFF
--- a/src/utils/useId.ts
+++ b/src/utils/useId.ts
@@ -17,7 +17,9 @@ limitations under the License.
 // eslint-disable-next-line no-restricted-imports
 import * as React from "react";
 
-const react18UseId = (React as { useId?: () => string }).useId;
+// This abomination appears to be needed for consumers that rely on Webpack until
+// https://github.com/webpack/webpack/issues/14814 is fixed
+const react18UseId = (React as any)["useId".toString()];
 
 const getUniqueId = (() => {
   let index = 1;

--- a/src/utils/useId.ts
+++ b/src/utils/useId.ts
@@ -19,6 +19,7 @@ import * as React from "react";
 
 // This abomination appears to be needed for consumers that rely on Webpack until
 // https://github.com/webpack/webpack/issues/14814 is fixed
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const react18UseId = (React as any)["useId".toString()];
 
 const getUniqueId = (() => {


### PR DESCRIPTION
I'm still running into issues with `useId` on https://github.com/vector-im/element-web/pull/26229#issuecomment-1777065139. According to https://github.com/webpack/webpack/issues/14814, the only viable workaround appears to be making the usage unanalyzable. 🤷