### PR TITLE
Alert: add actions input

### DIFF
--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -17,13 +17,24 @@ limitations under the License.
 /* TODO: Review entire file for semantic token definiton */
 
 .alert {
+  --gap: var(--cpd-space-3x);
+  --padding: var(--cpd-space-4x);
+
   display: flex;
   align-items: start;
   justify-content: start;
-  gap: var(--cpd-space-3x);
-  padding: var(--cpd-space-4x);
+  gap: var(--gap);
+  padding: var(--padding);
   border-radius: 8px;
   border: 1px solid;
+
+  /* calculate magic width for text content based on min total width of 600
+  minus padding, icon + gap, close + gap
+  TODO 600px should be a token */
+  --wrap-magic-width: calc(
+    600px - var(--padding) - var(--padding) - var(--gap) - var(--gap) - 24px -
+      var(--cpd-icon-button-size)
+  );
 }
 
 .alert[data-type="success"] {
@@ -43,6 +54,19 @@ limitations under the License.
 
 .content {
   flex: 1;
+  display: flex;
+  flex-direction: row;
+  gap: var(--cpd-space-3x);
+}
+
+.with-actions .content {
+  flex-wrap: wrap;
+}
+
+.text-content {
+  flex: 1 1 0;
+  inline-size: min(100%, var(--wrap-magic-width));
+  min-inline-size: min(100%, var(--wrap-magic-width));
 }
 
 [data-type="success"] :is(.title, .icon) {
@@ -59,4 +83,16 @@ limitations under the License.
 
 .alert p {
   margin: 0;
+}
+
+.actions {
+  flex: 0;
+  display: flex;
+  flex-direction: row;
+  gap: var(--cpd-space-1x);
+  align-self: center;
+}
+
+.icon {
+  flex-shrink: 0;
 }

--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -17,24 +17,15 @@ limitations under the License.
 /* TODO: Review entire file for semantic token definiton */
 
 .alert {
-  --gap: var(--cpd-space-3x);
-  --padding: var(--cpd-space-4x);
-
+  container-type: inline-size;
+  container-name: alert;
   display: flex;
   align-items: start;
   justify-content: start;
-  gap: var(--gap);
-  padding: var(--padding);
+  gap: var(--cpd-space-3x);
+  padding: var(--cpd-space-4x);
   border-radius: 8px;
   border: 1px solid;
-
-  /* calculate magic width for text content based on min total width of 600
-  minus padding, icon + gap, close + gap
-  TODO 600px should be a token */
-  --wrap-magic-width: calc(
-    600px - var(--padding) - var(--padding) - var(--gap) - var(--gap) - 24px -
-      var(--cpd-icon-button-size)
-  );
 }
 
 .alert[data-type="success"] {
@@ -59,14 +50,8 @@ limitations under the License.
   gap: var(--cpd-space-3x);
 }
 
-.with-actions .content {
-  flex-wrap: wrap;
-}
-
 .text-content {
   flex: 1 1 0;
-  inline-size: min(100%, var(--wrap-magic-width));
-  min-inline-size: min(100%, var(--wrap-magic-width));
 }
 
 [data-type="success"] :is(.title, .icon) {
@@ -95,4 +80,17 @@ limitations under the License.
 
 .icon {
   flex-shrink: 0;
+}
+
+/* @TODO 600px break should be a token */
+
+/* wrap actions into a stacked layout when the alert is <=600px */
+@container alert (max-width: 600px) {
+  .content {
+    flex-wrap: wrap;
+  }
+
+  .text-content {
+    flex: 1 0 100%;
+  }
 }

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from "react";
 import { Meta } from "@storybook/react";
+import { Button } from "../Button/Button";
 
 import { Alert as AlertComponent } from "./Alert";
 
@@ -58,6 +60,22 @@ export const Critical = {
 export const Info = {
   args: {
     type: "info",
+  },
+};
+
+export const WithActions = {
+  args: {
+    type: "info",
+    title:
+      "Long title. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    children:
+      "Actions are vertically centered against alert content. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    actions: (
+      <>
+        <Button>Yes</Button>
+        <Button>No</Button>
+      </>
+    ),
   },
 };
 

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -23,35 +23,55 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
+import { composeStory } from "@storybook/react";
 
-import { Alert } from "./Alert";
+import Meta, {
+  Success,
+  Critical,
+  Info,
+  WithActions,
+  WithoutClose,
+} from "./Alert.stories";
 
 describe("Alert", () => {
-  it("renders", () => {
-    const { asFragment } = render(
-      <Alert title="Title" type="success">
-        Success!
-      </Alert>,
-    );
+  it("renders success", () => {
+    const Component = composeStory(Success, Meta);
+    const { asFragment } = render(<Component />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders critical", () => {
+    const Component = composeStory(Critical, Meta);
+    const { asFragment } = render(<Component />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders info", () => {
+    const Component = composeStory(Info, Meta);
+    const { asFragment } = render(<Component />);
     expect(asFragment()).toMatchSnapshot();
   });
 
   it("has no close button by default", () => {
-    render(
-      <Alert title="Title" type="info">
-        Click me!
-      </Alert>,
-    );
+    const Component = composeStory(WithoutClose, Meta);
+    render(<Component />);
+
     expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
   });
 
   it("can have a close button", async () => {
     const spy = vi.fn();
-    const { container } = render(
-      <Alert title="Title" type="critical" onClose={spy}>
-        Click me!
-      </Alert>,
+    const Component = composeStory(
+      {
+        ...Success,
+        args: {
+          ...Success.args,
+          onClose: spy,
+        },
+      },
+      Meta,
     );
+    const { container } = render(<Component />);
 
     await waitFor(() =>
       expect(getByLabelText(container, "Close")).toBeInTheDocument(),
@@ -60,5 +80,11 @@ describe("Alert", () => {
     fireEvent.click(getByLabelText(container, "Close"));
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders actions", () => {
+    const Component = composeStory(WithActions, Meta);
+    const { asFragment } = render(<Component />);
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -40,8 +40,14 @@ type AlertProps = {
    */
   className?: string;
   /**
-   * Alert actions that will be displayed to the right of the message
-   * in the alert
+   * Actions that will be displayed to the right of the content
+   * eg
+   * ```
+   * <Alert
+   *  title='Title'
+   *  actions={<Button onClick={doSomething}>Yes</Button>}
+   * />
+   * ```
    */
   actions?: React.ReactNode;
   /**

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -40,6 +40,10 @@ type AlertProps = {
    */
   className?: string;
   /**
+   *
+   */
+  actions?: React.ReactNode;
+  /**
    * Event callback when dismissing the alert. Determines the display of the
    * "close" button at the top right of the alert.
    * @param e the event parameters
@@ -56,10 +60,14 @@ export const Alert: React.FC<PropsWithChildren<AlertProps>> = ({
   title,
   children,
   className,
+  actions,
   onClose,
   ...props
 }: PropsWithChildren<AlertProps>) => {
-  const classes = classNames(styles.alert, className);
+  const classes = classNames(styles.alert, {
+    className,
+    [styles["with-actions"]]: !!actions,
+  });
 
   const renderIcon = useCallback(
     (props: React.ComponentProps<typeof ErrorIcon>) => {
@@ -84,12 +92,15 @@ export const Alert: React.FC<PropsWithChildren<AlertProps>> = ({
         "aria-hidden": true,
       })}
       <div className={styles.content}>
-        <Text size="md" weight="semibold">
-          {title}
-        </Text>
-        <Text size="sm" weight="regular">
-          {children}
-        </Text>
+        <div className={styles["text-content"]}>
+          <Text size="md" weight="semibold">
+            {title}
+          </Text>
+          <Text size="sm" weight="regular">
+            {children}
+          </Text>
+        </div>
+        {actions && <div className={styles.actions}>{actions}</div>}
       </div>
       {/* TODO: Setup an i18n function for the aria label below */}
       {onClose && (

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -40,7 +40,8 @@ type AlertProps = {
    */
   className?: string;
   /**
-   *
+   * Alert actions that will be displayed to the right of the message
+   * in the alert
    */
   actions?: React.ReactNode;
   /**

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -41,6 +41,7 @@ type AlertProps = {
   className?: string;
   /**
    * Actions that will be displayed to the right of the content
+   * Wraps and stacks actions under content when alert's size is <=600px
    * eg
    * ```
    * <Alert
@@ -71,10 +72,7 @@ export const Alert: React.FC<PropsWithChildren<AlertProps>> = ({
   onClose,
   ...props
 }: PropsWithChildren<AlertProps>) => {
-  const classes = classNames(styles.alert, {
-    className,
-    [styles["with-actions"]]: !!actions,
-  });
+  const classes = classNames(styles.alert, className);
 
   const renderIcon = useCallback(
     (props: React.ComponentProps<typeof ErrorIcon>) => {

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,6 +1,234 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Alert > renders 1`] = `
+exports[`Alert > renders actions 1`] = `
+<DocumentFragment>
+  <div
+    class="_alert_6cfd7b _with-actions_6cfd7b"
+    data-type="info"
+  >
+    <svg
+      aria-hidden="true"
+      class="_icon_6cfd7b"
+      fill="none"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.2875 7.2875C11.4792 7.09583 11.7167 7 12 7C12.2833 7 12.5208 7.09583 12.7125 7.2875C12.9042 7.47917 13 7.71667 13 8C13 8.28333 12.9042 8.52083 12.7125 8.7125C12.5208 8.90417 12.2833 9 12 9C11.7167 9 11.4792 8.90417 11.2875 8.7125C11.0958 8.52083 11 8.28333 11 8C11 7.71667 11.0958 7.47917 11.2875 7.2875Z"
+        fill="currentColor"
+      />
+      <path
+        d="M11.2875 11.2875C11.4792 11.0958 11.7167 11 12 11C12.2833 11 12.5208 11.0958 12.7125 11.2875C12.9042 11.4792 13 11.7167 13 12V16C13 16.2833 12.9042 16.5208 12.7125 16.7125C12.5208 16.9042 12.2833 17 12 17C11.7167 17 11.4792 16.9042 11.2875 16.7125C11.0958 16.5208 11 16.2833 11 16V12C11 11.7167 11.0958 11.4792 11.2875 11.2875Z"
+        fill="currentColor"
+      />
+      <path
+        clip-rule="evenodd"
+        d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+    <div
+      class="_content_6cfd7b"
+    >
+      <div
+        class="_text-content_6cfd7b"
+      >
+        <p
+          class="_font-body-md-semibold_489030"
+        >
+          Long title. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+        <p
+          class="_font-body-sm-regular_489030"
+        >
+          Actions are vertically centered against alert content. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+      </div>
+      <div
+        class="_actions_6cfd7b"
+      >
+        <button
+          class="_button_2a1efe"
+          data-kind="primary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          Yes
+        </button>
+        <button
+          class="_button_2a1efe"
+          data-kind="primary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          No
+        </button>
+      </div>
+    </div>
+    <button
+      aria-label="Close"
+      class="_icon-button_1d4528 _close_6cfd7b"
+      role="button"
+      style="--cpd-icon-button-size: 32px;"
+    >
+      <svg
+        class="cpd-icon"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.29289 6.29289C6.68342 5.90237 7.31658 5.90237 7.70711 6.29289L12 10.5858L16.2929 6.29289C16.6834 5.90237 17.3166 5.90237 17.7071 6.29289C18.0976 6.68342 18.0976 7.31658 17.7071 7.70711L13.4142 12L17.7071 16.2929C18.0976 16.6834 18.0976 17.3166 17.7071 17.7071C17.3166 18.0976 16.6834 18.0976 16.2929 17.7071L12 13.4142L7.70711 17.7071C7.31658 18.0976 6.68342 18.0976 6.29289 17.7071C5.90237 17.3166 5.90237 16.6834 6.29289 16.2929L10.5858 12L6.29289 7.70711C5.90237 7.31658 5.90237 6.68342 6.29289 6.29289Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Alert > renders critical 1`] = `
+<DocumentFragment>
+  <div
+    class="_alert_6cfd7b"
+    data-type="critical"
+  >
+    <svg
+      aria-hidden="true"
+      class="_icon_6cfd7b"
+      fill="none"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 17C12.2833 17 12.5208 16.9042 12.7125 16.7125C12.9042 16.5208 13 16.2833 13 16C13 15.7167 12.9042 15.4792 12.7125 15.2875C12.5208 15.0958 12.2833 15 12 15C11.7167 15 11.4792 15.0958 11.2875 15.2875C11.0958 15.4792 11 15.7167 11 16C11 16.2833 11.0958 16.5208 11.2875 16.7125C11.4792 16.9042 11.7167 17 12 17ZM12 13C12.2833 13 12.5208 12.9042 12.7125 12.7125C12.9042 12.5208 13 12.2833 13 12V8C13 7.71667 12.9042 7.47917 12.7125 7.2875C12.5208 7.09583 12.2833 7 12 7C11.7167 7 11.4792 7.09583 11.2875 7.2875C11.0958 7.47917 11 7.71667 11 8V12C11 12.2833 11.0958 12.5208 11.2875 12.7125C11.4792 12.9042 11.7167 13 12 13ZM12 22C10.6167 22 9.31667 21.7375 8.1 21.2125C6.88333 20.6875 5.825 19.975 4.925 19.075C4.025 18.175 3.3125 17.1167 2.7875 15.9C2.2625 14.6833 2 13.3833 2 12C2 10.6167 2.2625 9.31667 2.7875 8.1C3.3125 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.3125 8.1 2.7875C9.31667 2.2625 10.6167 2 12 2C13.3833 2 14.6833 2.2625 15.9 2.7875C17.1167 3.3125 18.175 4.025 19.075 4.925C19.975 5.825 20.6875 6.88333 21.2125 8.1C21.7375 9.31667 22 10.6167 22 12C22 13.3833 21.7375 14.6833 21.2125 15.9C20.6875 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6875 15.9 21.2125C14.6833 21.7375 13.3833 22 12 22Z"
+        fill="currentColor"
+      />
+    </svg>
+    <div
+      class="_content_6cfd7b"
+    >
+      <div
+        class="_text-content_6cfd7b"
+      >
+        <p
+          class="_font-body-md-semibold_489030"
+        >
+          Title
+        </p>
+        <p
+          class="_font-body-sm-regular_489030"
+        >
+          Description
+        </p>
+      </div>
+    </div>
+    <button
+      aria-label="Close"
+      class="_icon-button_1d4528 _close_6cfd7b"
+      role="button"
+      style="--cpd-icon-button-size: 32px;"
+    >
+      <svg
+        class="cpd-icon"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.29289 6.29289C6.68342 5.90237 7.31658 5.90237 7.70711 6.29289L12 10.5858L16.2929 6.29289C16.6834 5.90237 17.3166 5.90237 17.7071 6.29289C18.0976 6.68342 18.0976 7.31658 17.7071 7.70711L13.4142 12L17.7071 16.2929C18.0976 16.6834 18.0976 17.3166 17.7071 17.7071C17.3166 18.0976 16.6834 18.0976 16.2929 17.7071L12 13.4142L7.70711 17.7071C7.31658 18.0976 6.68342 18.0976 6.29289 17.7071C5.90237 17.3166 5.90237 16.6834 6.29289 16.2929L10.5858 12L6.29289 7.70711C5.90237 7.31658 5.90237 6.68342 6.29289 6.29289Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Alert > renders info 1`] = `
+<DocumentFragment>
+  <div
+    class="_alert_6cfd7b"
+    data-type="info"
+  >
+    <svg
+      aria-hidden="true"
+      class="_icon_6cfd7b"
+      fill="none"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.2875 7.2875C11.4792 7.09583 11.7167 7 12 7C12.2833 7 12.5208 7.09583 12.7125 7.2875C12.9042 7.47917 13 7.71667 13 8C13 8.28333 12.9042 8.52083 12.7125 8.7125C12.5208 8.90417 12.2833 9 12 9C11.7167 9 11.4792 8.90417 11.2875 8.7125C11.0958 8.52083 11 8.28333 11 8C11 7.71667 11.0958 7.47917 11.2875 7.2875Z"
+        fill="currentColor"
+      />
+      <path
+        d="M11.2875 11.2875C11.4792 11.0958 11.7167 11 12 11C12.2833 11 12.5208 11.0958 12.7125 11.2875C12.9042 11.4792 13 11.7167 13 12V16C13 16.2833 12.9042 16.5208 12.7125 16.7125C12.5208 16.9042 12.2833 17 12 17C11.7167 17 11.4792 16.9042 11.2875 16.7125C11.0958 16.5208 11 16.2833 11 16V12C11 11.7167 11.0958 11.4792 11.2875 11.2875Z"
+        fill="currentColor"
+      />
+      <path
+        clip-rule="evenodd"
+        d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+    <div
+      class="_content_6cfd7b"
+    >
+      <div
+        class="_text-content_6cfd7b"
+      >
+        <p
+          class="_font-body-md-semibold_489030"
+        >
+          Title
+        </p>
+        <p
+          class="_font-body-sm-regular_489030"
+        >
+          Description
+        </p>
+      </div>
+    </div>
+    <button
+      aria-label="Close"
+      class="_icon-button_1d4528 _close_6cfd7b"
+      role="button"
+      style="--cpd-icon-button-size: 32px;"
+    >
+      <svg
+        class="cpd-icon"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.29289 6.29289C6.68342 5.90237 7.31658 5.90237 7.70711 6.29289L12 10.5858L16.2929 6.29289C16.6834 5.90237 17.3166 5.90237 17.7071 6.29289C18.0976 6.68342 18.0976 7.31658 17.7071 7.70711L13.4142 12L17.7071 16.2929C18.0976 16.6834 18.0976 17.3166 17.7071 17.7071C17.3166 18.0976 16.6834 18.0976 16.2929 17.7071L12 13.4142L7.70711 17.7071C7.31658 18.0976 6.68342 18.0976 6.29289 17.7071C5.90237 17.3166 5.90237 16.6834 6.29289 16.2929L10.5858 12L6.29289 7.70711C5.90237 7.31658 5.90237 6.68342 6.29289 6.29289Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Alert > renders success 1`] = `
 <DocumentFragment>
   <div
     class="_alert_6cfd7b"
@@ -23,17 +251,41 @@ exports[`Alert > renders 1`] = `
     <div
       class="_content_6cfd7b"
     >
-      <p
-        class="_font-body-md-semibold_489030"
+      <div
+        class="_text-content_6cfd7b"
       >
-        Title
-      </p>
-      <p
-        class="_font-body-sm-regular_489030"
-      >
-        Success!
-      </p>
+        <p
+          class="_font-body-md-semibold_489030"
+        >
+          Title
+        </p>
+        <p
+          class="_font-body-sm-regular_489030"
+        >
+          Description
+        </p>
+      </div>
     </div>
+    <button
+      aria-label="Close"
+      class="_icon-button_1d4528 _close_6cfd7b"
+      role="button"
+      style="--cpd-icon-button-size: 32px;"
+    >
+      <svg
+        class="cpd-icon"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.29289 6.29289C6.68342 5.90237 7.31658 5.90237 7.70711 6.29289L12 10.5858L16.2929 6.29289C16.6834 5.90237 17.3166 5.90237 17.7071 6.29289C18.0976 6.68342 18.0976 7.31658 17.7071 7.70711L13.4142 12L17.7071 16.2929C18.0976 16.6834 18.0976 17.3166 17.7071 17.7071C17.3166 18.0976 16.6834 18.0976 16.2929 17.7071L12 13.4142L7.70711 17.7071C7.31658 18.0976 6.68342 18.0976 6.29289 17.7071C5.90237 17.3166 5.90237 16.6834 6.29289 16.2929L10.5858 12L6.29289 7.70711C5.90237 7.31658 5.90237 6.68342 6.29289 6.29289Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Alert > renders actions 1`] = `
 <DocumentFragment>
   <div
-    class="_alert_6cfd7b _with-actions_6cfd7b"
+    class="_alert_6cfd7b"
     data-type="info"
   >
     <svg


### PR DESCRIPTION

https://github.com/vector-im/compound-web/assets/3055605/94565ce5-f995-49b8-8ee8-dfa7f0252485

Fixes https://github.com/vector-im/compound/issues/250

- [x] Changed: Set description text to `font.body.sm.regular`
- [x] Added: New variant with a stacked layout. Actions on the bottom.
- [x] Added: New variant with a 2 column layout. Actions on the right column, vertically centered. It should shift to stacked layout when the component width (container query) is below 600px.
- [x] Bug: The corner radius should be 8px.
- [x] Bug: The close/dismiss button is not correctly sized.

[Figma — Alert Component](https://www.figma.com/file/rTaQE2nIUSLav4Tg3nozq7/Compound-Web-Components?type=design&node-id=795-7802&mode=design&t=UVgZk0pPlOaqkhma-0)