### PR TITLE
Forms: make ligatures opt-in on inputs

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -37,12 +37,12 @@ exports[`Alert > renders actions 1`] = `
         class="_text-content_6cfd7b"
       >
         <p
-          class="_font-body-md-semibold_489030"
+          class="_typography_489030 _font-body-md-semibold_489030"
         >
           Long title. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
         <p
-          class="_font-body-sm-regular_489030"
+          class="_typography_489030 _font-body-sm-regular_489030"
         >
           Actions are vertically centered against alert content. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
@@ -121,12 +121,12 @@ exports[`Alert > renders critical 1`] = `
         class="_text-content_6cfd7b"
       >
         <p
-          class="_font-body-md-semibold_489030"
+          class="_typography_489030 _font-body-md-semibold_489030"
         >
           Title
         </p>
         <p
-          class="_font-body-sm-regular_489030"
+          class="_typography_489030 _font-body-sm-regular_489030"
         >
           Description
         </p>
@@ -193,12 +193,12 @@ exports[`Alert > renders info 1`] = `
         class="_text-content_6cfd7b"
       >
         <p
-          class="_font-body-md-semibold_489030"
+          class="_typography_489030 _font-body-md-semibold_489030"
         >
           Title
         </p>
         <p
-          class="_font-body-sm-regular_489030"
+          class="_typography_489030 _font-body-sm-regular_489030"
         >
           Description
         </p>
@@ -255,12 +255,12 @@ exports[`Alert > renders success 1`] = `
         class="_text-content_6cfd7b"
       >
         <p
-          class="_font-body-md-semibold_489030"
+          class="_typography_489030 _font-body-md-semibold_489030"
         >
           Title
         </p>
         <p
-          class="_font-body-sm-regular_489030"
+          class="_typography_489030 _font-body-sm-regular_489030"
         >
           Description
         </p>

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge > renders 1`] = `
 <DocumentFragment>
   <span
-    class="_font-body-sm-medium_489030 _badge_f1986f"
+    class="_typography_489030 _font-body-sm-medium_489030 _badge_f1986f"
     data-kind="default"
   />
 </DocumentFragment>

--- a/src/components/Form/Controls/Text/Text.module.css
+++ b/src/components/Form/Controls/Text/Text.module.css
@@ -21,6 +21,13 @@ limitations under the License.
   border-radius: 0.5rem;
   padding: var(--cpd-space-3x) var(--cpd-space-4x);
   box-sizing: border-box;
+
+  /**
+  * Disable contextual alternate ligatures in inputs
+  * https://github.com/rsms/inter/issues/222
+  * https://github.com/rsms/inter/blob/master/src/features/calt.fea
+  */
+  font-feature-settings: "calt" 0;
 }
 
 @media (hover) {
@@ -60,11 +67,6 @@ limitations under the License.
   color: var(--cpd-color-text-secondary);
 }
 
-/**
-* Disable contextual alternate ligatures in inputs
-* https://github.com/rsms/inter/issues/222
-* https://github.com/rsms/inter/blob/master/src/features/calt.fea
-*/
-.disable-ligatures {
-  font-feature-settings: "calt" 0;
+.control.enable-ligatures {
+  font-feature-settings: var(--cpd-font-feature-settings);
 }

--- a/src/components/Form/Controls/Text/Text.module.css
+++ b/src/components/Form/Controls/Text/Text.module.css
@@ -59,3 +59,12 @@ limitations under the License.
   border-color: var(--cpd-color-bg-subtle-secondary);
   color: var(--cpd-color-text-secondary);
 }
+
+/**
+* Disable contextual alternate ligatures in inputs
+* https://github.com/rsms/inter/issues/222
+* https://github.com/rsms/inter/blob/master/src/features/calt.fea
+*/
+.disable-ligatures {
+  font-feature-settings: "calt" 0;
+}

--- a/src/components/Form/Controls/Text/Text.stories.tsx
+++ b/src/components/Form/Controls/Text/Text.stories.tsx
@@ -84,7 +84,11 @@ export const Empty: Story = {
 
 export const Filled: Story = {
   args: {
-    defaultValue: "Filled",
+    /**
+     * Use this text to check ligatures are disabled in inputs
+     * Once visual testing is reinstated
+     */
+    defaultValue: "Difficult waffles",
   },
   parameters: {
     design: {

--- a/src/components/Form/Controls/Text/Text.stories.tsx
+++ b/src/components/Form/Controls/Text/Text.stories.tsx
@@ -88,7 +88,7 @@ export const Filled: Story = {
      * Use this text to check ligatures are disabled in inputs
      * Once visual testing is reinstated
      */
-    defaultValue: "Difficult waffles",
+    defaultValue: "-> 1x2x3 1/4",
   },
   parameters: {
     design: {

--- a/src/components/Form/Controls/Text/Text.stories.tsx
+++ b/src/components/Form/Controls/Text/Text.stories.tsx
@@ -36,7 +36,7 @@ export default {
         "autoFocus",
         "readOnly",
         "dataInvalid",
-        "disableLigatures",
+        "enableLigatures",
       ],
     },
   },
@@ -59,7 +59,7 @@ export default {
     invalid: {
       type: "boolean",
     },
-    disableLigatures: {
+    enableLigatures: {
       type: "boolean",
     },
   },
@@ -72,7 +72,7 @@ export default {
     disabled: false,
     readOnly: false,
     invalid: false,
-    disableLigatures: false,
+    enableLigatures: undefined,
   },
 } satisfies Meta<Props>;
 
@@ -90,7 +90,7 @@ export const Empty: Story = {
 export const Filled: Story = {
   args: {
     /**
-     * Use this text to check ligatures are displayed in inputs
+     * Use this text to check ligatures are not displayed in inputs
      * Once visual testing is reinstated
      */
     defaultValue: "-> 1x2x3",
@@ -103,14 +103,14 @@ export const Filled: Story = {
   },
 };
 
-export const WithoutLigatures: Story = {
+export const WithLigatures: Story = {
   args: {
     /**
-     * Use this text to check ligatures are disabled by disableLigatures
+     * Use this text to check ligatures are enabled by enableLigatures
      * Once visual testing is reinstated
      */
     defaultValue: "-> 1x2x3",
-    disableLigatures: true,
+    enableLigatures: true,
   },
   parameters: {
     design: {

--- a/src/components/Form/Controls/Text/Text.stories.tsx
+++ b/src/components/Form/Controls/Text/Text.stories.tsx
@@ -36,6 +36,7 @@ export default {
         "autoFocus",
         "readOnly",
         "dataInvalid",
+        "disableLigatures",
       ],
     },
   },
@@ -58,6 +59,9 @@ export default {
     invalid: {
       type: "boolean",
     },
+    disableLigatures: {
+      type: "boolean",
+    },
   },
   render: ({ invalid, ...restArgs }) => (
     <TextInput data-invalid={invalid || undefined} {...restArgs} />
@@ -68,6 +72,7 @@ export default {
     disabled: false,
     readOnly: false,
     invalid: false,
+    disableLigatures: false,
   },
 } satisfies Meta<Props>;
 
@@ -85,10 +90,27 @@ export const Empty: Story = {
 export const Filled: Story = {
   args: {
     /**
-     * Use this text to check ligatures are disabled in inputs
+     * Use this text to check ligatures are displayed in inputs
      * Once visual testing is reinstated
      */
-    defaultValue: "-> 1x2x3 1/4",
+    defaultValue: "-> 1x2x3",
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/rTaQE2nIUSLav4Tg3nozq7/Compound-Web-Components?type=design&node-id=792-2724",
+    },
+  },
+};
+
+export const WithoutLigatures: Story = {
+  args: {
+    /**
+     * Use this text to check ligatures are disabled by disableLigatures
+     * Once visual testing is reinstated
+     */
+    defaultValue: "-> 1x2x3",
+    disableLigatures: true,
   },
   parameters: {
     design: {

--- a/src/components/Form/Controls/Text/Text.test.tsx
+++ b/src/components/Form/Controls/Text/Text.test.tsx
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { composeStories } from "@storybook/react";
+
+import * as stories from "./Text.stories";
+
+const { Empty, Filled, WithoutLigatures, Disabled, ReadOnly, Invalid } =
+  composeStories(stories);
+
+describe("<Text />", () => {
+  it("renders an empty input", () => {
+    const { container } = render(<Empty />);
+    expect(container).toMatchSnapshot();
+  });
+  it("renders a filled input", () => {
+    const { container } = render(<Filled />);
+    expect(container).toMatchSnapshot();
+  });
+  it("renders a input with ligatures disabled", () => {
+    const { container } = render(<WithoutLigatures />);
+    expect(container).toMatchSnapshot();
+  });
+  it("renders a disabled input", () => {
+    const { container } = render(<Disabled />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it("renders a read only input", () => {
+    const { container } = render(<ReadOnly />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it("renders an invalid input", () => {
+    const { container } = render(<Invalid />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/Form/Controls/Text/Text.test.tsx
+++ b/src/components/Form/Controls/Text/Text.test.tsx
@@ -21,7 +21,7 @@ import { composeStories } from "@storybook/react";
 
 import * as stories from "./Text.stories";
 
-const { Empty, Filled, WithoutLigatures, Disabled, ReadOnly, Invalid } =
+const { Empty, Filled, WithLigatures, Disabled, ReadOnly, Invalid } =
   composeStories(stories);
 
 describe("<Text />", () => {
@@ -33,8 +33,8 @@ describe("<Text />", () => {
     const { container } = render(<Filled />);
     expect(container).toMatchSnapshot();
   });
-  it("renders a input with ligatures disabled", () => {
-    const { container } = render(<WithoutLigatures />);
+  it("renders a input with ligatures enable", () => {
+    const { container } = render(<WithLigatures />);
     expect(container).toMatchSnapshot();
   });
   it("renders a disabled input", () => {

--- a/src/components/Form/Controls/Text/Text.tsx
+++ b/src/components/Form/Controls/Text/Text.tsx
@@ -28,12 +28,12 @@ type TextProps = {
   className?: string;
 
   /**
-   * Disable contextual alternate ligatures on input text
-   * For example on a username field
+   * Enable contextual alternate ligatures on input text
+   * For example on an in-place editing field
    * https://github.com/rsms/inter/issues/222
    * https://github.com/rsms/inter/blob/master/src/features/calt.fea
    */
-  disableLigatures?: boolean;
+  enableLigatures?: boolean;
 } & ComponentProps<"input">;
 
 /**
@@ -44,7 +44,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextProps>(
     const classes = classNames(
       styles.control,
       props.className,
-      props.disableLigatures && styles["disable-ligatures"],
+      props.enableLigatures && styles["enable-ligatures"],
     );
     return <input ref={ref} {...props} className={classes} />;
   },

--- a/src/components/Form/Controls/Text/Text.tsx
+++ b/src/components/Form/Controls/Text/Text.tsx
@@ -26,6 +26,14 @@ type TextProps = {
    * The CSS class name.
    */
   className?: string;
+
+  /**
+   * Disable contextual alternate ligatures on input text
+   * For example on a username field
+   * https://github.com/rsms/inter/issues/222
+   * https://github.com/rsms/inter/blob/master/src/features/calt.fea
+   */
+  disableLigatures?: boolean;
 } & ComponentProps<"input">;
 
 /**
@@ -33,7 +41,11 @@ type TextProps = {
  */
 export const TextInput = forwardRef<HTMLInputElement, TextProps>(
   function TextInput(props, ref) {
-    const classes = classNames(styles.control, props.className);
+    const classes = classNames(
+      styles.control,
+      props.className,
+      props.disableLigatures && styles["disable-ligatures"],
+    );
     return <input ref={ref} {...props} className={classes} />;
   },
 );

--- a/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
@@ -1,0 +1,72 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<Text /> > renders a disabled input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    disabled=""
+    placeholder=""
+    value="Disabled"
+  />
+</div>
+`;
+
+exports[`<Text /> > renders a filled input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    placeholder=""
+    value="-> 1x2x3"
+  />
+</div>
+`;
+
+exports[`<Text /> > renders a input with ligatures disabled 1`] = `
+<div>
+  <input
+    class="_control_a839aa _disable-ligatures_a839aa"
+    placeholder=""
+    value="-> 1x2x3"
+  />
+</div>
+`;
+
+exports[`<Text /> > renders a read only input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    placeholder=""
+    readonly=""
+    value="Read only"
+  />
+</div>
+`;
+
+exports[`<Text /> > renders an Empty input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    placeholder=""
+  />
+</div>
+`;
+
+exports[`<Text /> > renders an empty input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    placeholder=""
+  />
+</div>
+`;
+
+exports[`<Text /> > renders an invalid input 1`] = `
+<div>
+  <input
+    class="_control_a839aa"
+    data-invalid="true"
+    placeholder=""
+    value="Invalid"
+  />
+</div>
+`;

--- a/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
@@ -31,6 +31,16 @@ exports[`<Text /> > renders a input with ligatures disabled 1`] = `
 </div>
 `;
 
+exports[`<Text /> > renders a input with ligatures enable 1`] = `
+<div>
+  <input
+    class="_control_a839aa _enable-ligatures_a839aa"
+    placeholder=""
+    value="-> 1x2x3"
+  />
+</div>
+`;
+
 exports[`<Text /> > renders a read only input 1`] = `
 <div>
   <input

--- a/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
@@ -42,15 +42,6 @@ exports[`<Text /> > renders a read only input 1`] = `
 </div>
 `;
 
-exports[`<Text /> > renders an Empty input 1`] = `
-<div>
-  <input
-    class="_control_a839aa"
-    placeholder=""
-  />
-</div>
-`;
-
 exports[`<Text /> > renders an empty input 1`] = `
 <div>
   <input

--- a/src/components/Menu/__snapshots__/DrawerMenu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/DrawerMenu.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`DrawerMenu > renders 1`] = `
           />
         </svg>
         <span
-          class="_font-body-md-medium_489030 _label_37eef5"
+          class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
         >
           Profile
         </span>
@@ -89,7 +89,7 @@ exports[`DrawerMenu > renders 1`] = `
           />
         </svg>
         <span
-          class="_font-body-md-medium_489030 _label_37eef5"
+          class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
         >
           Sign out
         </span>

--- a/src/components/Menu/__snapshots__/FloatingMenu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/FloatingMenu.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`FloatingMenu > renders 1`] = `
     role="menu"
   >
     <h3
-      class="_font-body-sm-semibold_489030 _title_3295a1"
+      class="_typography_489030 _font-body-sm-semibold_489030 _title_3295a1"
       id=":r0:"
     >
       Settings
@@ -41,7 +41,7 @@ exports[`FloatingMenu > renders 1`] = `
         />
       </svg>
       <span
-        class="_font-body-md-medium_489030 _label_37eef5"
+        class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
       >
         Profile
       </span>
@@ -91,7 +91,7 @@ exports[`FloatingMenu > renders 1`] = `
         />
       </svg>
       <span
-        class="_font-body-md-medium_489030 _label_37eef5"
+        class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
       >
         Sign out
       </span>

--- a/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`MenuItem > renders 1`] = `
       />
     </svg>
     <span
-      class="_font-body-md-medium_489030 _label_37eef5"
+      class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
     >
       Leave room
     </span>
@@ -82,7 +82,7 @@ exports[`MenuItem > renders with a child 1`] = `
       />
     </svg>
     <span
-      class="_font-body-md-medium_489030 _label_37eef5"
+      class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
     >
       People
     </span>
@@ -101,7 +101,7 @@ exports[`MenuItem > renders with a child 1`] = `
       />
     </svg>
     <span
-      class="_font-body-sm-regular_489030"
+      class="_typography_489030 _font-body-sm-regular_489030"
     >
       10
     </span>

--- a/src/components/MenuItem/__snapshots__/ToggleMenuItem.test.tsx.snap
+++ b/src/components/MenuItem/__snapshots__/ToggleMenuItem.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ToggleMenuItem > renders 1`] = `
       />
     </svg>
     <span
-      class="_font-body-md-medium_489030 _label_37eef5"
+      class="_typography_489030 _font-body-md-medium_489030 _label_37eef5"
     >
       Always show
     </span>

--- a/src/components/Typography/Text.stories.tsx
+++ b/src/components/Typography/Text.stories.tsx
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Text as TextComponent } from "./Text";
 
@@ -31,19 +30,20 @@ export default {
       options: ["regular", "medium", "semibold"],
       control: { type: "inline-radio" },
     },
+    children: {
+      type: "string",
+    },
+  },
+  args: {
+    children: "The quick brown fox jumps over the lazy dog",
+    size: "md",
+    weight: "regular",
   },
 } as Meta<typeof TextComponent>;
 
-const Template: StoryFn<typeof TextComponent> = (
-  args: Partial<React.ComponentProps<typeof Text>>,
-) => (
-  <TextComponent size={args.size} weight={args.weight}>
-    The quick brown fox jumps over the lazy dog
-  </TextComponent>
-);
-
-export const Text = Template.bind({});
-Text.args = {
-  size: "md",
-  weight: "regular",
+export const Text = {};
+export const Ligatures = {
+  args: {
+    children: "-> 1x2x3",
+  },
 };

--- a/src/components/Typography/Typography.module.css
+++ b/src/components/Typography/Typography.module.css
@@ -150,3 +150,15 @@ limitations under the License.
   letter-spacing: var(--cpd-font-letter-spacing-heading-xl);
   font: var(--cpd-font-heading-xl-semibold);
 }
+
+/**
+  * Reset font-feature-settings after letter-spacing has been tweaked.
+  * We want to apply Inter Dynamic metrics (https://rsms.me/inter/dynmetrics/)
+  * We need to tweak the `letter-spacing` property and doing so, disables by
+  * default the optional ligatures
+  * `font-feature-settings` allows us to override this behaviour and have the
+  * correct ligatures and the proper dynamic metric spacing.
+  */
+.typography {
+  font-feature-settings: var(--cpd-font-feature-settings);
+}

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -58,6 +58,7 @@ export const Typography = <C extends React.ElementType = "p">({
     <Component
       {...restProps}
       className={classNames(
+        styles.typography,
         styles[`font-${type}-${size}-${weight}`],
         className,
       )}

--- a/src/components/Typography/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Typography/__snapshots__/Heading.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Heading > renders 1`] = `
 <DocumentFragment>
   <h1
-    class="_font-heading-md-regular_489030"
+    class="_typography_489030 _font-heading-md-regular_489030"
   >
     The quick brown fox jumps over the lazy dog.
   </h1>

--- a/src/components/Typography/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Typography/__snapshots__/Text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Body > renders 1`] = `
 <DocumentFragment>
   <p
-    class="_font-body-md-regular_489030"
+    class="_typography_489030 _font-body-md-regular_489030"
   >
     The quick brown fox jumps over the lazy dog.
   </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,6 +21,15 @@ limitations under the License.
   /* Default icon and avatar size */
   --cpd-icon-button-size: var(--cpd-space-8x);
   --cpd-avatar-size: var(--cpd-space-16x);
+
+  /**
+  * We want to apply Inter Dynamic metrics (https://rsms.me/inter/dynmetrics/)
+  * We need to tweak the `letter-spacing` property and doing so, disables by
+  * default the optional ligatures
+  * `font-feature-settings` allows us to override this behaviour and have the
+  * correct ligatures and the proper dynamic metric spacing.
+  */
+  --cpd-font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
 }
 
 html,
@@ -34,18 +43,7 @@ html,
 body {
   block-size: 100%;
   font-size: var(--cpd-font-size-root);
-
-  /**
-  * We want to apply Inter Dynamic metrics (https://rsms.me/inter/dynmetrics/)
-  * We need to tweak the `letter-spacing` property and doing so, disables by
-  * default the optional ligatures
-  * `font-feature-settings` allows us to override this behaviour and have the
-  * correct ligatures and the proper dynamic metric spacing.
-  */
-  font-feature-settings:
-    "kern" 1,
-    "liga" 1,
-    "calt" 1;
+  font-feature-settings: var(--cpd-font-feature-settings);
 }
 
 /**

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,22 +37,13 @@ body,
 input {
   font: var(--cpd-font-body-md-regular);
   color: var(--cpd-color-text-primary);
+  font-feature-settings: var(--cpd-font-feature-settings);
 }
 
 html,
 body {
   block-size: 100%;
   font-size: var(--cpd-font-size-root);
-  font-feature-settings: var(--cpd-font-feature-settings);
-}
-
-/**
-* Disable contextual alternate ligatures in inputs
-* https://github.com/rsms/inter/issues/222
-* https://github.com/rsms/inter/blob/master/src/features/calt.fea
-*/
-input {
-  font-feature-settings: "calt" 0;
 }
 
 body {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,8 +49,9 @@ body {
 }
 
 /**
-* Disable ligatures in inputs
+* Disable contextual alternate ligatures in inputs
 * https://github.com/rsms/inter/issues/222
+* https://github.com/rsms/inter/blob/master/src/features/calt.fea
 */
 input {
   font-feature-settings: "calt" 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,26 @@ html,
 body {
   block-size: 100%;
   font-size: var(--cpd-font-size-root);
+
+  /**
+  * We want to apply Inter Dynamic metrics (https://rsms.me/inter/dynmetrics/)
+  * We need to tweak the `letter-spacing` property and doing so, disables by
+  * default the optional ligatures
+  * `font-feature-settings` allows us to override this behaviour and have the
+  * correct ligatures and the proper dynamic metric spacing.
+  */
+  font-feature-settings:
+    "kern" 1,
+    "liga" 1,
+    "calt" 1;
+}
+
+/**
+* Disable ligatures in inputs
+* https://github.com/rsms/inter/issues/222
+*/
+input {
+  font-feature-settings: "calt" 0;
 }
 
 body {


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25538

Adds `disableLigatures` prop to `Form.Text`
Default behaviour is for ligatures to match the rest of typography, ie enabled.

<img width="289" alt=" " src="https://github.com/vector-im/compound-web/assets/3055605/ab3d52c0-100a-48c4-98a3-a2f9731d3c03">


See:
- https://57d2e811.compound-web.pages.dev/?path=/story/typography--ligatures
- https://57d2e811.compound-web.pages.dev/?path=/story/form-controls-text--filled
