### PR TITLE
Fix `Typography` > `Heading` > `H4`

### DIFF
--- a/src/components/Typography/Heading.tsx
+++ b/src/components/Typography/Heading.tsx
@@ -78,7 +78,7 @@ export const H3: React.FC<HeadingProps> = ({ children, ...props }) => {
  */
 export const H4: React.FC<HeadingProps> = ({ children, ...props }) => {
   return (
-    <Heading as="h1" weight="semibold" size="sm" {...props}>
+    <Heading as="h4" weight="semibold" size="sm" {...props}>
       {children}
     </Heading>
   );


### PR DESCRIPTION
Small mistake on the html attribute used for the `H4` component.