### PR TITLE
Fix `Typography` > `Heading` and `Text` size

### DIFF
--- a/src/components/Typography/Heading.stories.tsx
+++ b/src/components/Typography/Heading.stories.tsx
@@ -25,7 +25,7 @@ export default {
   component: HeadingComponent,
   argTypes: {
     size: {
-      options: ["xs", "sm", "md", "lg"],
+      options: ["sm", "md", "lg", "xl"],
       control: { type: "inline-radio" },
     },
     weight: {

--- a/src/components/Typography/Heading.tsx
+++ b/src/components/Typography/Heading.tsx
@@ -18,11 +18,16 @@ import React from "react";
 import { Typography } from "./Typography";
 import { Text } from "./Text";
 
+type TypographyProps = React.ComponentProps<typeof Typography>;
+
 /**
  * A heading component.
  */
 export const Heading: React.FC<
-  Omit<React.ComponentProps<typeof Typography>, "type">
+  Omit<TypographyProps, "type"> & {
+    // xs is not a valid heading size
+    size?: Exclude<TypographyProps["size"], "xs">;
+  }
 > = ({ as = "h1", children, ...props }) => {
   return (
     <Typography as={as} type="heading" {...props}>

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -17,12 +17,17 @@ limitations under the License.
 import React from "react";
 import { Typography } from "./Typography";
 
+type TypographyProps = React.ComponentProps<typeof Typography>;
+
 /**
  * A text component. Underlying HTML element can be changed using the `as`
  * property. Will default to be a paragraph.
  */
 export const Text: React.FC<
-  Omit<React.ComponentProps<typeof Typography>, "type">
+  Omit<TypographyProps, "type"> & {
+    // xl is not a valid text size
+    size?: Exclude<TypographyProps["size"], "xl">;
+  }
 > = ({ as = "p", children, ...props }) => {
   return (
     <Typography as={as} type="body" {...props}>

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -36,7 +36,7 @@ type TypographyProps<C extends React.ElementType> = {
   /**
    * The t-shirt size of the content.
    */
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
   /**
    * The CSS class name.
    */


### PR DESCRIPTION
Fix https://github.com/vector-im/compound/issues/271

- There is no `xs` size for heading in https://github.com/vector-im/compound-web/blob/main/src/components/Typography/Typography.module.css and https://github.com/vector-im/compound-design-tokens/blob/main/assets/web/css/cpd-common.css
- I excluded the `xs` size for the `Heading` component
- The `xl` size used in the [`H1` component](https://github.com/vector-im/compound-web/blob/main/src/components/Typography/Heading.tsx#L45) was not defined in the `Typography` component
- `xl` is not available for `Text/Body` component (https://github.com/vector-im/compound-web/blob/main/src/components/Typography/Typography.module.css)

TLDR: `xs` is only available for `Text/Body`. `xl` is only available for `Heading`.